### PR TITLE
fix(reconcile): git-add scope, sensitive ordering, repo-order (from live e2e)

### DIFF
--- a/reconcile/index.js
+++ b/reconcile/index.js
@@ -86,9 +86,11 @@ async function sh(cmd, args, opts = {}) {
     return;
   }
 
-  // 3. Stage tracked source changes (composer.json/lock, patches/, patches.lock.json).
-  //    Installed plugins/themes are gitignored vendored artifacts — they are not committed.
-  await sh('git', ['add', '-A'], { cwd });
+  // 3. Stage ONLY the reconcile outputs — not `git add -A`, which would also commit
+  //    build-injected files (mu-plugins, generated drop-ins) that aren't source changes.
+  const OUTPUT_PATHS = ['composer.json', 'composer.lock', 'patches', 'patches.lock.json', '.patches_applied'];
+  const toStage = OUTPUT_PATHS.filter((p) => fs.existsSync(path.join(cwd, p)));
+  if (toStage.length) await sh('git', ['add', '--', ...toStage], { cwd });
   const staged = await sh('git', ['diff', '--cached', '--name-only'], { cwd });
   if (!staged.out.trim()) {
     await core.summary.addRaw(body).write();

--- a/reconcile/lib/classify.js
+++ b/reconcile/lib/classify.js
@@ -62,10 +62,6 @@ async function componentVerdict(comp, ctx) {
   const { resolvers, treeRoot, modifiedPaths = new Set() } = ctx;
   const label = `${comp.kind} ${comp.slug}`;
 
-  if (comp.paths.some((it) => isSensitive(it.path))) {
-    return { key: comp.slug, category: 'sensitive', recoverable: false,
-      remediation: `Sensitive file inside ${label}. Review manually.` };
-  }
   if (comp.paths.every((it) => isIgnorable(it.path))) {
     return { key: comp.slug, category: 'ignorable', recoverable: false,
       remediation: `All drift in ${label} is runtime/junk. Add to SSH_IGNORE_LIST.` };
@@ -87,6 +83,13 @@ async function componentVerdict(comp, ctx) {
     return { key: comp.slug, category: res.source, recoverable: true,
       composerPackage: res.package, version: pin, root: comp.root, kind: comp.kind,
       remediation: `Add/bump \`${res.package}:${versionConstraint(pin)}\` in composer.json (server has ${label}${treeVersion ? ` v${treeVersion}` : ''}).` };
+  }
+
+  // Not resolvable to a package: only now consider flags. A sensitive-looking file bundled
+  // inside a resolvable plugin must NOT block the add above — composer installs pristine.
+  if (comp.paths.some((it) => isSensitive(it.path))) {
+    return { key: comp.slug, category: 'sensitive', recoverable: false,
+      remediation: `Sensitive file inside ${label}, which is not resolvable to a package. Review manually.` };
   }
 
   if (comp.paths.every((it) => isCompiledAsset(it.path) || isVendorPath(it.path))) {

--- a/reconcile/lib/composer.js
+++ b/reconcile/lib/composer.js
@@ -54,4 +54,47 @@ function ensureCweagansSetup(composer) {
   return { composer: next, changed };
 }
 
-module.exports = { upsertRequire, ensureCweagansSetup };
+/** Find a top-level `"key": {...}` or `"key": [...]` block, brace-balanced and string-aware. */
+function extractKeyBlock(text, key) {
+  const m = text.match(new RegExp(`"${key}"\\s*:\\s*`));
+  if (!m) return null;
+  let i = m.index + m[0].length;
+  const open = text[i];
+  if (open !== '{' && open !== '[') return null;
+  const close = open === '{' ? '}' : ']';
+  let depth = 0;
+  let inStr = false;
+  let esc = false;
+  for (; i < text.length; i++) {
+    const ch = text[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (ch === '\\') esc = true;
+      else if (ch === '"') inStr = false;
+    } else if (ch === '"') inStr = true;
+    else if (ch === open) depth++;
+    else if (ch === close && --depth === 0) return { start: m.index, end: i + 1, text: text.slice(m.index, i + 1) };
+  }
+  return null;
+}
+
+/**
+ * Serialize composer.json. Splices the original `repositories` block back so composer's
+ * integer-indexed repository keys (e.g. "0") are not reordered by JSON.stringify's
+ * integer-key hoisting — keeping the reconciliation diff limited to real changes.
+ * ponytail: only `repositories` is preserved — the one composer key that uses numeric indices.
+ * @param {object} obj
+ * @param {string} [originalText] the composer.json we read before editing (require untouched)
+ * @returns {string}
+ */
+function serializeComposer(obj, originalText) {
+  let out = JSON.stringify(obj, null, 4) + '\n';
+  if (originalText) {
+    const orig = extractKeyBlock(originalText, 'repositories');
+    const cur = extractKeyBlock(out, 'repositories');
+    if (orig && cur) out = out.slice(0, cur.start) + orig.text + out.slice(cur.end);
+  }
+  return out;
+}
+
+module.exports = { upsertRequire, ensureCweagansSetup, serializeComposer };

--- a/reconcile/lib/reconcile-patched.js
+++ b/reconcile/lib/reconcile-patched.js
@@ -2,6 +2,7 @@
 const fs = require('fs');
 const path = require('path');
 const { generatePatch, upsertExtraPatches } = require('./patch-gen');
+const { serializeComposer } = require('./composer');
 
 /**
  * @param {object} o
@@ -24,10 +25,11 @@ async function reconcilePatched(o) {
   //    against the previously-patched state and the regenerated patch would not
   //    apply cleanly from pristine.
   if (fs.existsSync(composerPath)) {
-    const c0 = JSON.parse(fs.readFileSync(composerPath, 'utf8'));
+    const c0text = fs.readFileSync(composerPath, 'utf8');
+    const c0 = JSON.parse(c0text);
     if (c0.extra && c0.extra.patches && c0.extra.patches[o.pkg]) {
       delete c0.extra.patches[o.pkg];
-      fs.writeFileSync(composerPath, JSON.stringify(c0, null, 4) + '\n');
+      fs.writeFileSync(composerPath, serializeComposer(c0, c0text));
       // Relock so the removed patch is no longer applied on the next install.
       await o.runner.composer(['patches-relock'], { cwd: o.projectDir });
     }
@@ -46,13 +48,14 @@ async function reconcilePatched(o) {
   const patchFile = `./patches/${o.slug}.patch`;
   fs.writeFileSync(path.join(o.projectDir, 'patches', `${o.slug}.patch`), patch);
 
-  const composer = JSON.parse(fs.readFileSync(composerPath, 'utf8'));
+  const composerText = fs.readFileSync(composerPath, 'utf8');
+  const composer = JSON.parse(composerText);
   const { composer: next } = upsertExtraPatches(composer, o.pkg, {
     description: `Reconciled from server drift for ${o.slug}`,
     url: patchFile,
     depth: 2,
   });
-  fs.writeFileSync(composerPath, JSON.stringify(next, null, 4) + '\n');
+  fs.writeFileSync(composerPath, serializeComposer(next, composerText));
 
   // 4. Relock + apply.
   await o.runner.composer(['patches-relock'], { cwd: o.projectDir });

--- a/reconcile/lib/reconcile-run.js
+++ b/reconcile/lib/reconcile-run.js
@@ -4,7 +4,7 @@ const path = require('path');
 const { parseManifest } = require('./parse-drift');
 const { parseContentDiff, modifiedPaths } = require('./parse-content-diff');
 const { classify, versionConstraint } = require('./classify');
-const { upsertRequire, ensureCweagansSetup } = require('./composer');
+const { upsertRequire, ensureCweagansSetup, serializeComposer } = require('./composer');
 const { decideOutcome } = require('./outcome');
 const { reconcilePatched } = require('./reconcile-patched');
 
@@ -27,7 +27,8 @@ async function reconcileRun(o) {
 
   const composerPath = path.join(o.sourceDir, 'composer.json');
   const hasComposer = fs.existsSync(composerPath);
-  let composer = hasComposer ? JSON.parse(fs.readFileSync(composerPath, 'utf8')) : null;
+  const originalComposerText = hasComposer ? fs.readFileSync(composerPath, 'utf8') : null;
+  let composer = originalComposerText ? JSON.parse(originalComposerText) : null;
   let composerChanged = false;
   const applied = [];
   const toUpdate = new Set();
@@ -65,7 +66,7 @@ async function reconcileRun(o) {
     if (r.changed) composerChanged = true;
     toUpdate.add(c.composerPackage);
   }
-  if (composerChanged) fs.writeFileSync(composerPath, JSON.stringify(composer, null, 4) + '\n');
+  if (composerChanged) fs.writeFileSync(composerPath, serializeComposer(composer, originalComposerText));
 
   // Resolve the new constraints so installed plugins reflect them.
   if (toUpdate.size && o.runner) {

--- a/reconcile/test/classify.test.js
+++ b/reconcile/test/classify.test.js
@@ -106,3 +106,21 @@ test('resolvable component verdict carries root and kind', async () => {
   assert.strictEqual(c.root, 'plugins/code-snippets');
   assert.strictEqual(c.kind, 'plugin');
 });
+
+test('resolvable plugin with a sensitive-looking bundled file still classifies as an add', async () => {
+  const items = [
+    { path: 'plugins/code-snippets/code-snippets.php', side: 'remote-only' },
+    { path: 'plugins/code-snippets/includes/wp-config-helper.php', side: 'remote-only' }, // matches sensitive regex
+  ];
+  const out = await classify(items, { resolvers, treeRoot: '/nonexistent' });
+  const c = findKey(out, 'code-snippets');
+  assert.strictEqual(c.category, 'wpackagist-plugin');
+  assert.strictEqual(c.recoverable, true);
+});
+
+test('non-resolvable plugin with a sensitive file is still flagged sensitive', async () => {
+  const out = await classify([{ path: 'plugins/unknownplug/secret-credentials.php', side: 'remote-only' }], { resolvers, treeRoot: '/nonexistent' });
+  const c = findKey(out, 'unknownplug');
+  assert.strictEqual(c.category, 'sensitive');
+  assert.strictEqual(c.recoverable, false);
+});

--- a/reconcile/test/composer.test.js
+++ b/reconcile/test/composer.test.js
@@ -1,7 +1,7 @@
 'use strict';
 const test = require('node:test');
 const assert = require('node:assert');
-const { upsertRequire, ensureCweagansSetup } = require('../lib/composer');
+const { upsertRequire, ensureCweagansSetup, serializeComposer } = require('../lib/composer');
 
 test('adds a new package and reports changed', () => {
   const base = { require: { 'php': '>=8.1' } };
@@ -36,4 +36,28 @@ test('ensureCweagansSetup preserves an existing post-install-cmd and is idempote
   const again = ensureCweagansSetup(first);
   assert.strictEqual(again.changed, false);
   assert.strictEqual(again.composer.scripts['post-install-cmd'].length, first.scripts['post-install-cmd'].length);
+});
+
+test('serializeComposer keeps the original repositories order (no integer-key hoisting)', () => {
+  const original = [
+    '{',
+    '    "name": "t/t",',
+    '    "repositories": {',
+    '        "satispress": { "type": "composer", "url": "https://packages.saucal.com/satispress/" },',
+    '        "0": { "type": "composer", "url": "https://wpackagist.org" }',
+    '    },',
+    '    "require": { "php": ">=8.1" }',
+    '}',
+    '',
+  ].join('\n');
+  const obj = JSON.parse(original); // JSON.parse hoists "0" ahead of "satispress"
+  obj.require['wpackagist-plugin/x'] = '>=1.0.0';
+  const out = serializeComposer(obj, original);
+  assert.ok(out.indexOf('"satispress"') < out.indexOf('"0"'), `repositories reordered:\n${out}`);
+  assert.match(out, /"wpackagist-plugin\/x": ">=1\.0\.0"/);
+  assert.deepStrictEqual(JSON.parse(out).repositories, obj.repositories);
+});
+
+test('serializeComposer without original text is plain stringify', () => {
+  assert.strictEqual(serializeComposer({ a: 1 }), JSON.stringify({ a: 1 }, null, 4) + '\n');
 });


### PR DESCRIPTION
Fixes surfaced by the ci-test-ftp live run (PR #95):
1. Stage only reconcile outputs, not `git add -A` (was committing build-injected mu-plugins).
2. Resolve a plugin before the sensitive check (a bundled file no longer blocks a legit add).
3. Preserve `repositories` order (no integer-key hoisting) for a clean diff.

60 unit + 14 integration green. Still flag-gated behind SAUCAL_CONSISTENCY_RECONCILE.