### PR TITLE
Gate reconcile adds on composer availability

### DIFF
--- a/reconcile/lib/composer.js
+++ b/reconcile/lib/composer.js
@@ -16,6 +16,20 @@ function upsertRequire(composer, pkg, constraint) {
   return { composer: next, changed };
 }
 
+/**
+ * Remove a require entry (used to revert an add whose constraint composer couldn't satisfy).
+ * Returns a new object (input untouched).
+ * @param {object} composer
+ * @param {string} pkg
+ * @returns {{composer:object, changed:boolean}}
+ */
+function removeRequire(composer, pkg) {
+  const next = JSON.parse(JSON.stringify(composer || {}));
+  const changed = !!(next.require && Object.prototype.hasOwnProperty.call(next.require, pkg));
+  if (next.require) delete next.require[pkg];
+  return { composer: next, changed };
+}
+
 const CWEAGANS = 'cweagans/composer-patches';
 // From saucal's "Automatically patching a plugin" doc: cweagans 2.0 has a lock file but
 // does not respect it on install, so this reinstall-on-hash-change hook is required.
@@ -97,4 +111,4 @@ function serializeComposer(obj, originalText) {
   return out;
 }
 
-module.exports = { upsertRequire, ensureCweagansSetup, serializeComposer };
+module.exports = { upsertRequire, removeRequire, ensureCweagansSetup, serializeComposer };

--- a/reconcile/lib/reconcile-run.js
+++ b/reconcile/lib/reconcile-run.js
@@ -4,7 +4,7 @@ const path = require('path');
 const { parseManifest } = require('./parse-drift');
 const { parseContentDiff, modifiedPaths } = require('./parse-content-diff');
 const { classify, versionConstraint } = require('./classify');
-const { upsertRequire, ensureCweagansSetup, serializeComposer } = require('./composer');
+const { upsertRequire, removeRequire, ensureCweagansSetup, serializeComposer } = require('./composer');
 const { decideOutcome } = require('./outcome');
 const { reconcilePatched } = require('./reconcile-patched');
 
@@ -30,8 +30,8 @@ async function reconcileRun(o) {
   const originalComposerText = hasComposer ? fs.readFileSync(composerPath, 'utf8') : null;
   let composer = originalComposerText ? JSON.parse(originalComposerText) : null;
   let composerChanged = false;
+  let bootstrapCweagans = false;
   const applied = [];
-  const toUpdate = new Set();
 
   // Patch reconciliation needs cweagans/composer-patches. If a modified-from-published plugin
   // is present but the project lacks it, BOOTSTRAP the setup into the PR (per saucal's
@@ -45,7 +45,7 @@ async function reconcileRun(o) {
       composer = b.composer;
       if (b.changed) {
         composerChanged = true;
-        toUpdate.add('cweagans/composer-patches');
+        bootstrapCweagans = true;
         applied.push('bootstrap:cweagans');
       }
     } else {
@@ -58,20 +58,45 @@ async function reconcileRun(o) {
     }
   }
 
-  // Pass 1 — require add/bump (also pins patched-candidate to its target version).
+  // Persist the cweagans bootstrap (and install it) before touching plugin requires.
+  if (composerChanged) fs.writeFileSync(composerPath, serializeComposer(composer, originalComposerText));
+  if (bootstrapCweagans && o.runner) {
+    const upd = await o.runner.composer(['update', 'cweagans/composer-patches', '-W', '--no-progress'], { cwd: o.sourceDir });
+    if (upd.code !== 0) applied.push('bootstrap:cweagans:update-failed');
+  }
+
+  // Pass 1 — require add/bump (also pins patched-candidate to its target version), applied ONE
+  // package at a time so composer's resolver acts as the availability check. The version is
+  // derived from the server's plugin header; if no published package satisfies `>=<version>`
+  // (e.g. the server runs a dev/unreleased build), composer update fails — we then REVERT the
+  // constraint (never commit an uninstallable composer.json) and flag it as a decision rather
+  // than reporting a false "Applied". Without this, merging the PR would not bring the site
+  // back in sync. ponytail: sequential updates (n small); batch if a repo ever adds dozens.
   for (const c of classified) {
     if (!c.recoverable || !c.composerPackage || !composer) continue;
-    const r = upsertRequire(composer, c.composerPackage, versionConstraint(c.version));
-    composer = r.composer;
-    if (r.changed) composerChanged = true;
-    toUpdate.add(c.composerPackage);
-  }
-  if (composerChanged) fs.writeFileSync(composerPath, serializeComposer(composer, originalComposerText));
+    const constraint = versionConstraint(c.version);
+    const had = !!(composer.require && Object.prototype.hasOwnProperty.call(composer.require, c.composerPackage));
+    const prev = had ? composer.require[c.composerPackage] : undefined;
 
-  // Resolve the new constraints so installed plugins reflect them.
-  if (toUpdate.size && o.runner) {
-    await o.runner.composer(['update', ...toUpdate, '-W', '--no-progress'], { cwd: o.sourceDir });
-    for (const p of toUpdate) applied.push(`require:${p}`);
+    const r = upsertRequire(composer, c.composerPackage, constraint);
+    composer = r.composer;
+    fs.writeFileSync(composerPath, serializeComposer(composer, originalComposerText));
+
+    if (!o.runner) { if (r.changed) composerChanged = true; continue; }
+
+    const upd = await o.runner.composer(['update', c.composerPackage, '-W', '--no-progress'], { cwd: o.sourceDir });
+    if (upd.code !== 0) {
+      // Unsatisfiable — restore the prior constraint (or drop the add) so composer.json stays installable.
+      composer = (had ? upsertRequire(composer, c.composerPackage, prev) : removeRequire(composer, c.composerPackage)).composer;
+      fs.writeFileSync(composerPath, serializeComposer(composer, originalComposerText));
+      c.recoverable = false;
+      c.category = 'version-unavailable';
+      c.remediation = `Server has ${c.key}${c.version ? ` v${c.version}` : ''}, but no published package satisfies \`${c.composerPackage}:${constraint}\` — composer could not install it, so merging would not bring the site in sync. Publish it to SatisPress (or correct the version) and re-run.`;
+      applied.push(`require:${c.composerPackage}:unavailable`);
+      continue;
+    }
+    if (r.changed) composerChanged = true;
+    applied.push(`require:${c.composerPackage}`);
   }
 
   // Pass 2 — patches for modified-from-published (after the package is at its target version).

--- a/reconcile/test/integration/scenarios.integration.test.js
+++ b/reconcile/test/integration/scenarios.integration.test.js
@@ -377,6 +377,54 @@ test('mixed: add + patch + junk -> all categories, outcome reconciled', async ()
   assert.match(read(path.join(dir, 'plugins/patchplug/patchplug.php')), /DRIFTED/, 'patchplug patched');
 });
 
+// --- 11. unavailable version --------------------------------------------
+test('unavailable: server version exceeds anything published -> flagged, composer.json not broken', async () => {
+  // futureplug exists as a path repo at 1.0.0 only; server claims 2.0.0.
+  const { dir } = makeProject({
+    plugins: [
+      { slug: 'baseplug', pkg: 'saucal/baseplug', version: '1.0.0', body: '// base\n' },
+      { slug: 'futureplug', pkg: 'saucal/futureplug', version: '1.0.0', body: '// future\n' },
+    ],
+  });
+  const composerPath = path.join(dir, 'composer.json');
+  const composer = JSON.parse(read(composerPath));
+  delete composer.require['saucal/futureplug'];
+  fs.writeFileSync(composerPath, JSON.stringify(composer, null, 4) + '\n');
+  const runner = makeRunner();
+  let r = await runner.composer(['update', 'saucal/futureplug', '-W', '--no-progress'], { cwd: dir });
+  assert.strictEqual(r.code, 0, r.stderr);
+  const composerBefore = read(composerPath);
+
+  // resolver maps futureplug -> package, but the server header (2.0.0) drives the pin.
+  const resolvers = {
+    async wpackagist() { return null; },
+    async satispress(slug) {
+      if (slug === 'futureplug') return { source: 'satispress', package: 'saucal/futureplug', version: '1.0.0' };
+      return null;
+    },
+  };
+
+  const serverDir = stageServer(dir, (sv) => {
+    const d = path.join(sv, 'plugins/futureplug');
+    fs.mkdirSync(d, { recursive: true });
+    fs.writeFileSync(path.join(d, 'futureplug.php'),
+      '<?php\n/**\n * Plugin Name: futureplug\n * Version: 2.0.0\n */\n// future\n');
+  });
+
+  const { manifestText, contentDiffText } = deriveDrift(dir, serverDir);
+  const res = await reconcileRun({ sourceDir: dir, treeRoot: serverDir, manifestText, contentDiffText, resolvers, runner });
+
+  const c = findByKey(res.classified, 'futureplug');
+  assert.strictEqual(c.category, 'version-unavailable', `category: ${c && c.category}`);
+  assert.strictEqual(c.recoverable, false);
+  // composer.json is still installable — the unsatisfiable constraint was reverted.
+  const after = JSON.parse(read(composerPath));
+  assert.ok(!after.require['saucal/futureplug'], 'unavailable add reverted out of require');
+  assert.ok(after.require['saucal/baseplug'], 'existing deps preserved');
+  assert.strictEqual(read(composerPath), composerBefore, 'composer.json byte-identical to pre-reconcile');
+  assert.ok(res.applied.includes('require:saucal/futureplug:unavailable'), `applied: ${res.applied}`);
+});
+
 // --- 10. bootstrap cweagans on a repo that lacks it ---------------------
 test('bootstrap: repo without cweagans gets it installed + the plugin patched', async () => {
   const { dir } = makeProject({

--- a/reconcile/test/reconcile-run.test.js
+++ b/reconcile/test/reconcile-run.test.js
@@ -53,6 +53,24 @@ test('add/bump: recoverable wpackagist add writes require, runs composer update,
   assert.deepStrictEqual(res.applied, ['require:wpackagist-plugin/code-snippets']);
 });
 
+test('unavailable: composer update fails -> constraint reverted, flagged version-unavailable', async () => {
+  const sourceDir = tmpSource();
+  const before = fs.readFileSync(path.join(sourceDir, 'composer.json'), 'utf8');
+  // Runner that rejects the version (simulates "no published package satisfies the constraint").
+  const runner = { calls: [], composer(args, opts) { this.calls.push({ args, opts }); return { code: 1, stdout: '', stderr: 'not found' }; } };
+  const manifestText = 'deleting plugins/code-snippets/code-snippets.php\n';
+
+  const res = await reconcileRun({ sourceDir, treeRoot: '/nonexistent', manifestText, resolvers, runner });
+
+  const c = res.classified.find((x) => x.key === 'code-snippets');
+  assert.strictEqual(c.category, 'version-unavailable');
+  assert.strictEqual(c.recoverable, false);
+  // composer.json reverted to its original bytes — no uninstallable constraint left behind.
+  assert.strictEqual(fs.readFileSync(path.join(sourceDir, 'composer.json'), 'utf8'), before);
+  assert.ok(res.applied.includes('require:wpackagist-plugin/code-snippets:unavailable'), res.applied.join(','));
+  assert.strictEqual(res.outcome, 'unrecoverable-only');
+});
+
 test('flag-only: sensitive item leaves composer untouched, no runner call, empty applied', async () => {
   const sourceDir = tmpSource();
   const runner = fakeRunner();


### PR DESCRIPTION
## Problem

Reconcile Pass 1 ran a single fire-and-forget `composer update` and **ignored its exit code**. A version derived from the server's plugin header that no published package can satisfy (e.g. a plugin running a dev build → `>=4.0.0-dev2`) was written to `composer.json` and reported **✅ Applied** even though nothing installs. Merging that PR would never bring the site back in sync — the exact "assumed to be there" gap.

## Fix

Apply each add/bump **one package at a time** and let composer's own resolver be the availability gate:

- `composer update <pkg>` **succeeds** → genuine ✅ Applied (proven to install).
- **fails** → **revert** the constraint (restore a bumped dep's prior value, drop an add) so `composer.json` stays installable, and reclassify the drift `version-unavailable` → **⚠️ Needs review**, job stays **red**.

`>=` semantics are unchanged on purpose — it's load-bearing for the auto-update convergence model; an exact pin would drift the moment WP auto-updates.

### Net effect
Anything in the ✅ Applied list is now composer-verified to install, so a deploy from the merged PR reproduces the server. The only red items left are genuine decisions (unavailable version → publish to SatisPress, sensitive files, unresolvable premium plugins, unknown drift).

## Changes
- `lib/composer.js`: add `removeRequire`
- `lib/reconcile-run.js`: per-package verified apply + revert-on-failure; per-package cweagans bootstrap install
- Tests: +1 unit (revert-on-failure, offline fake runner), +1 integration (real composer — unavailable version flagged, `composer.json` byte-identical)

**61 unit / 15 integration — all green.**

Dormant behind `SAUCAL_CONSISTENCY_RECONCILE` like the rest of the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)