### PR TITLE
Give reconcile a real composer environment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -143,6 +143,14 @@ runs:
         name: ${{ steps.artifact-meta.outputs.prefix }}-consistency-diffs
         path: ${{ steps.pre-build-consistency-check.outputs.diffPath }}
 
+    - name: Setup PHP + Composer for reconcile
+      if: ${{ failure() && inputs.reconcile == '1' }}
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.2'
+        tools: composer
+        coverage: none
+
     - name: Reconcile drift
       if: ${{ failure() && inputs.reconcile == '1' }}
       shell: bash

--- a/reconcile/index.js
+++ b/reconcile/index.js
@@ -44,6 +44,15 @@ async function sh(cmd, args, opts = {}) {
   const satispressToken = env('SATISPRESS_TOKEN');
   const branch = `reconciliation-${ref}`;
 
+  // Authenticate composer against the SatisPress repo for every subprocess the reconcile runs
+  // (composer inherits process.env). Without this, `composer update` 401s on the private repo
+  // metadata and no add can be verified. Convention (from action-maintenance/.github/
+  // composer-update): username = the SatisPress key, password = the host domain.
+  if (satispressToken && !process.env.COMPOSER_AUTH) {
+    const host = (satispressUrl || 'https://packages.saucal.com').replace(/^https?:\/\//, '').replace(/\/.*$/, '');
+    process.env.COMPOSER_AUTH = JSON.stringify({ 'http-basic': { [host]: { username: satispressToken, password: host } } });
+  }
+
   if (!manifestPath || !fs.existsSync(manifestPath)) {
     core.warning('No drift manifest available; nothing to reconcile.');
     return;

--- a/reconcile/lib/reconcile-run.js
+++ b/reconcile/lib/reconcile-run.js
@@ -33,6 +33,22 @@ async function reconcileRun(o) {
   let bootstrapCweagans = false;
   const applied = [];
 
+  // Baseline install: probe the composer environment (PHP, composer binary, SatisPress auth)
+  // and materialise vendor/lock so per-package updates are incremental. If this fails, composer
+  // cannot verify anything here — surface the real cause (env/auth) instead of misreporting
+  // every add as "version-unavailable". Once it passes, a per-package update failure genuinely
+  // means that version is unsatisfiable.
+  const needsComposer = classified.some((c) => c.recoverable && c.composerPackage);
+  if (o.runner && hasComposer && needsComposer) {
+    const inst = await o.runner.composer(['install', '--no-progress'], { cwd: o.sourceDir });
+    if (inst.code !== 0) {
+      throw new Error(
+        'composer install failed in the reconcile environment — check PHP/composer setup and ' +
+        'SatisPress auth (COMPOSER_AUTH). Composer output:\n' + ((inst.stdout || '') + (inst.stderr || ''))
+      );
+    }
+  }
+
   // Patch reconciliation needs cweagans/composer-patches. If a modified-from-published plugin
   // is present but the project lacks it, BOOTSTRAP the setup into the PR (per saucal's
   // "Automatically patching a plugin" doc) so patch recovery works everywhere. Only when there

--- a/reconcile/test/reconcile-run.test.js
+++ b/reconcile/test/reconcile-run.test.js
@@ -42,13 +42,14 @@ test('add/bump: recoverable wpackagist add writes require, runs composer update,
   const composer = JSON.parse(fs.readFileSync(path.join(sourceDir, 'composer.json'), 'utf8'));
   assert.strictEqual(composer.require['wpackagist-plugin/code-snippets'], '>=3.6.5');
 
-  // fake runner received exactly one `composer update <pkg> -W` call.
-  assert.strictEqual(runner.calls.length, 1);
-  const { args, opts } = runner.calls[0];
-  assert.strictEqual(args[0], 'update');
-  assert.ok(args.includes('wpackagist-plugin/code-snippets'));
-  assert.ok(args.includes('-W'));
-  assert.strictEqual(opts.cwd, sourceDir);
+  // fake runner: a baseline `composer install` (env probe) then `composer update <pkg> -W`.
+  assert.strictEqual(runner.calls.length, 2);
+  assert.strictEqual(runner.calls[0].args[0], 'install');
+  const upd = runner.calls.find((k) => k.args[0] === 'update');
+  assert.ok(upd, 'an update call was made');
+  assert.ok(upd.args.includes('wpackagist-plugin/code-snippets'));
+  assert.ok(upd.args.includes('-W'));
+  assert.strictEqual(upd.opts.cwd, sourceDir);
 
   assert.deepStrictEqual(res.applied, ['require:wpackagist-plugin/code-snippets']);
 });
@@ -56,8 +57,15 @@ test('add/bump: recoverable wpackagist add writes require, runs composer update,
 test('unavailable: composer update fails -> constraint reverted, flagged version-unavailable', async () => {
   const sourceDir = tmpSource();
   const before = fs.readFileSync(path.join(sourceDir, 'composer.json'), 'utf8');
-  // Runner that rejects the version (simulates "no published package satisfies the constraint").
-  const runner = { calls: [], composer(args, opts) { this.calls.push({ args, opts }); return { code: 1, stdout: '', stderr: 'not found' }; } };
+  // Env works (install ok) but the version is unsatisfiable (update fails) — the exact case
+  // the availability gate must catch without misattributing it to a broken environment.
+  const runner = {
+    calls: [],
+    composer(args, opts) {
+      this.calls.push({ args, opts });
+      return { code: args[0] === 'install' ? 0 : 1, stdout: '', stderr: args[0] === 'install' ? '' : 'not found' };
+    },
+  };
   const manifestText = 'deleting plugins/code-snippets/code-snippets.php\n';
 
   const res = await reconcileRun({ sourceDir, treeRoot: '/nonexistent', manifestText, resolvers, runner });


### PR DESCRIPTION
Follow-up to #8. The availability gate only works if composer can actually run and authenticate in the runner — the consistency-check action had neither, so live on ci-test-ftp `composer update` 401'd instantly on the private SatisPress repo and the gate flagged **every** add `version-unavailable`, producing no PR (false negative).

## Changes
- **action.yml** — set up PHP 8.2 + composer before the reconcile step (gated on `failure() && reconcile == '1'`; normal checks unaffected).
- **index.js** — derive `COMPOSER_AUTH` from `SATISPRESS_TOKEN` so every composer subprocess authenticates against `packages.saucal.com`. Convention matches `action-maintenance/.github/composer-update`: **username = key, password = host**.
- **reconcile-run.js** — run a baseline `composer install` first as an environment probe. If it fails, **throw with composer's output** (surfacing broken env/auth) instead of misattributing to unavailable versions. Once it passes, a per-package update failure is a *genuine* availability failure → `version-unavailable`.

## Requires (infra)
Live verification needs the SatisPress key wired. Paired PR on action-maintenance fixes the workflow to pass `SAUCAL_SATIS_KEY || SAUCAL_GLOBAL_SATIS_KEY` (was a non-existent `SATIS_KEY`, hence the empty token). The org secret `SAUCAL_GLOBAL_SATIS_KEY` must be visible to ci-test-ftp.

**61 unit / 15 integration green.** Dormant behind `SAUCAL_CONSISTENCY_RECONCILE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)