### PR TITLE
Reconcile: partial-update-first + surface composer's unavailability reason

### DIFF
--- a/reconcile/index.js
+++ b/reconcile/index.js
@@ -87,6 +87,14 @@ async function sh(cmd, args, opts = {}) {
   const { classified, outcome, applied } = result;
   core.info(`Reconcile outcome: ${outcome} | applied: ${applied.join(', ') || '(none)'}`);
 
+  // Surface composer's actual complaint for anything flagged unavailable (why the version
+  // couldn't be installed: missing version, stability, or a broken global solve).
+  for (const c of classified) {
+    if (c.category === 'version-unavailable' && c.composerOutput) {
+      core.warning(`composer could not install ${c.composerPackage}:\n${c.composerOutput}`);
+    }
+  }
+
   const body = reportBody(classified, { ref, runUrl });
 
   if (outcome === 'noop') {

--- a/reconcile/lib/reconcile-run.js
+++ b/reconcile/lib/reconcile-run.js
@@ -100,7 +100,13 @@ async function reconcileRun(o) {
 
     if (!o.runner) { if (r.changed) composerChanged = true; continue; }
 
-    const upd = await o.runner.composer(['update', c.composerPackage, '-W', '--no-progress'], { cwd: o.sourceDir });
+    // Partial update first: keep every other package at its locked version so a pre-existing
+    // unsatisfiable sibling (e.g. a delisted plugin already in the repo) can't fail THIS plugin's
+    // solve. Escalate to -W only if the plugin genuinely needs its own dependencies co-updated.
+    let upd = await o.runner.composer(['update', c.composerPackage, '--no-progress'], { cwd: o.sourceDir });
+    if (upd.code !== 0) {
+      upd = await o.runner.composer(['update', c.composerPackage, '-W', '--no-progress'], { cwd: o.sourceDir });
+    }
     if (upd.code !== 0) {
       // Unsatisfiable — restore the prior constraint (or drop the add) so composer.json stays installable.
       composer = (had ? upsertRequire(composer, c.composerPackage, prev) : removeRequire(composer, c.composerPackage)).composer;

--- a/reconcile/lib/reconcile-run.js
+++ b/reconcile/lib/reconcile-run.js
@@ -107,7 +107,11 @@ async function reconcileRun(o) {
       fs.writeFileSync(composerPath, serializeComposer(composer, originalComposerText));
       c.recoverable = false;
       c.category = 'version-unavailable';
-      c.remediation = `Server has ${c.key}${c.version ? ` v${c.version}` : ''}, but no published package satisfies \`${c.composerPackage}:${constraint}\` — composer could not install it, so merging would not bring the site in sync. Publish it to SatisPress (or correct the version) and re-run.`;
+      // Surface composer's own reason so the log/PR say WHY (missing version vs. stability vs. a
+      // broken global solve), instead of an opaque "unavailable".
+      c.composerOutput = ((upd.stdout || '') + (upd.stderr || '')).trim().slice(-1600);
+      const reason = firstComposerError(c.composerOutput);
+      c.remediation = `Server has ${c.key}${c.version ? ` v${c.version}` : ''}, but composer could not install \`${c.composerPackage}:${constraint}\`${reason ? ` — ${reason}` : ''}. Merging would not bring the site in sync; resolve and re-run.`;
       applied.push(`require:${c.composerPackage}:unavailable`);
       continue;
     }
@@ -133,6 +137,14 @@ async function reconcileRun(o) {
   // Compute outcome last so the cweagans downgrade is reflected.
   const outcome = decideOutcome(classified);
   return { classified, outcome, applied };
+}
+
+/** Pull the most informative line out of composer's error output for a one-line reason. */
+function firstComposerError(out) {
+  if (!out) return '';
+  const lines = out.split('\n').map((l) => l.trim()).filter(Boolean);
+  const hit = lines.find((l) => /could not be found|requires|no matching package|minimum-stability|does not (?:match|allow)|conflict|Root composer\.json requires/i.test(l));
+  return (hit || lines[lines.length - 1] || '').slice(0, 300);
 }
 
 module.exports = { reconcileRun };

--- a/reconcile/test/reconcile-run.test.js
+++ b/reconcile/test/reconcile-run.test.js
@@ -42,13 +42,14 @@ test('add/bump: recoverable wpackagist add writes require, runs composer update,
   const composer = JSON.parse(fs.readFileSync(path.join(sourceDir, 'composer.json'), 'utf8'));
   assert.strictEqual(composer.require['wpackagist-plugin/code-snippets'], '>=3.6.5');
 
-  // fake runner: a baseline `composer install` (env probe) then `composer update <pkg> -W`.
+  // fake runner: a baseline `composer install` (env probe) then a partial `composer update <pkg>`
+  // (no -W — siblings stay locked). It succeeds, so no -W escalation.
   assert.strictEqual(runner.calls.length, 2);
   assert.strictEqual(runner.calls[0].args[0], 'install');
   const upd = runner.calls.find((k) => k.args[0] === 'update');
   assert.ok(upd, 'an update call was made');
   assert.ok(upd.args.includes('wpackagist-plugin/code-snippets'));
-  assert.ok(upd.args.includes('-W'));
+  assert.ok(!upd.args.includes('-W'), 'first update is partial (no -W)');
   assert.strictEqual(upd.opts.cwd, sourceDir);
 
   assert.deepStrictEqual(res.applied, ['require:wpackagist-plugin/code-snippets']);


### PR DESCRIPTION
Two changes, both aimed at the live ci-test-ftp failure where all three adds flag `version-unavailable`:

**1. Fix — partial `composer update` first, escalate to `-W` only if needed.**
A single-package `composer update <pkg> -W` re-solves the *entire* graph, so one pre-existing unsatisfiable sibling (a delisted plugin already in the repo) fails *every* plugin's update regardless of which is named. Now we try the partial update (no `-W`, siblings stay locked) first and escalate to `-W` only when the plugin needs its own deps co-updated. Isolates each add from a broken sibling, and is more faithful to reconcile's job (add the one drifted plugin, not upgrade the world).

**2. Observability — surface composer's actual reason.**
On update failure, capture composer's output, extract the salient error line into the PR remediation, and `core.warning` the full tail into the run log. So a `version-unavailable` flag now says *why* (missing version vs. stability vs. broken solve) instead of being opaque.

61 unit / 15 integration green. Dormant behind `SAUCAL_CONSISTENCY_RECONCILE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)