### PR TITLE
Reconcile: fix SatisPress auth delivery + reject illegal version constraints

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -166,7 +166,15 @@ runs:
         MANIFEST_PATH: ${{ steps.pre-build-consistency-check.outputs.bufferPath }}
         DIFF_PATH: ${{ steps.pre-build-consistency-check.outputs.diffPath }}
         RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-      run: node "$GITHUB_ACTION_PATH/reconcile/index.js"
+      run: |
+        # Authenticate composer against the private SatisPress repo the same way deployment does
+        # (global auth.json, read by every later composer call). composer loads ALL repo metadata
+        # on any update, so this is required even to add a wpackagist-only plugin.
+        if [ -n "$SATISPRESS_TOKEN" ]; then
+          host=$(printf '%s' "$SATISPRESS_URL" | sed -E 's,^https?://,,; s,/.*$,,')
+          composer config --global --auth "http-basic.$host" "$SATISPRESS_TOKEN" "$host"
+        fi
+        node "$GITHUB_ACTION_PATH/reconcile/index.js"
 
     - name: Signal Failure to slack
       if: ${{ failure() }}

--- a/reconcile/index.js
+++ b/reconcile/index.js
@@ -43,15 +43,8 @@ async function sh(cmd, args, opts = {}) {
   const satispressUrl = env('SATISPRESS_URL');
   const satispressToken = env('SATISPRESS_TOKEN');
   const branch = `reconciliation-${ref}`;
-
-  // Authenticate composer against the SatisPress repo for every subprocess the reconcile runs
-  // (composer inherits process.env). Without this, `composer update` 401s on the private repo
-  // metadata and no add can be verified. Convention (from action-maintenance/.github/
-  // composer-update): username = the SatisPress key, password = the host domain.
-  if (satispressToken && !process.env.COMPOSER_AUTH) {
-    const host = (satispressUrl || 'https://packages.saucal.com').replace(/^https?:\/\//, '').replace(/\/.*$/, '');
-    process.env.COMPOSER_AUTH = JSON.stringify({ 'http-basic': { [host]: { username: satispressToken, password: host } } });
-  }
+  // Composer SatisPress auth is configured by the action step (composer config --global --auth)
+  // before this script runs, so every composer subprocess here reads it from auth.json.
 
   if (!manifestPath || !fs.existsSync(manifestPath)) {
     core.warning('No drift manifest available; nothing to reconcile.');

--- a/reconcile/lib/classify.js
+++ b/reconcile/lib/classify.js
@@ -7,6 +7,14 @@ const WP_CORE_RE = /(?:^|\/)(?:wp-admin|wp-includes)\//;
 
 function versionConstraint(v) { return v ? `>=${v}` : '*'; }
 
+// A WordPress plugin header version isn't always a legal composer version (e.g. "4.0.0-dev2":
+// `dev2` is not a valid stability suffix, so `>=4.0.0-dev2` makes composer.json unparseable).
+// Only pin to versions composer can actually parse; otherwise fall back / leave unpinned.
+function isComposerVersion(v) {
+  return typeof v === 'string' &&
+    /^v?\d+(\.\d+){0,3}(?:[.-]?(?:alpha|beta|rc|a|b|p|patch|pl|stable)\.?\d*)?$/i.test(v.trim());
+}
+
 /**
  * @param {import('./parse-drift').DriftItem[]} items
  * @param {{resolvers:{wpackagist:Function,satispress:Function}, treeRoot:string}} ctx
@@ -73,12 +81,15 @@ async function componentVerdict(comp, ctx) {
 
   const res = (await resolvers.wpackagist(comp.kind, comp.slug)) || (await resolvers.satispress(comp.slug));
   if (res) {
-    const pin = treeVersion || res.version;
+    // Prefer the server's header version, but only if composer can parse it; else the resolver's
+    // (published) version; else leave unpinned (`*`) rather than emit a constraint composer rejects.
+    const pin = isComposerVersion(treeVersion) ? treeVersion
+      : (isComposerVersion(res.version) ? res.version : null);
     const isModified = comp.paths.some((it) => modifiedPaths.has(it.path));
     if (isModified) {
       return { key: comp.slug, category: 'patched-candidate', recoverable: true,
         composerPackage: res.package, version: pin, root: comp.root, kind: comp.kind,
-        remediation: `${label} is modified from its published version. Bump-first to v${pin}, then patch the residual (resolved at apply time).` };
+        remediation: `${label} is modified from its published version. Bump-first to ${pin ? `v${pin}` : 'its published version'}, then patch the residual (resolved at apply time).` };
     }
     return { key: comp.slug, category: res.source, recoverable: true,
       composerPackage: res.package, version: pin, root: comp.root, kind: comp.kind,
@@ -101,4 +112,4 @@ async function componentVerdict(comp, ctx) {
     remediation: `Premium/unknown ${label}${treeVersion ? ` v${treeVersion}` : ''} on server, not on wpackagist or SatisPress. Add to SatisPress or vendor manually.` };
 }
 
-module.exports = { classify, versionConstraint };
+module.exports = { classify, versionConstraint, isComposerVersion };

--- a/reconcile/test/classify.test.js
+++ b/reconcile/test/classify.test.js
@@ -4,7 +4,7 @@ const assert = require('node:assert');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { classify, versionConstraint } = require('../lib/classify');
+const { classify, versionConstraint, isComposerVersion } = require('../lib/classify');
 
 // Resolvers stub: code-snippets is on wpackagist, churn-solution on satispress, others unknown.
 const resolvers = {
@@ -24,6 +24,28 @@ function findKey(out, key) { return out.find((c) => c.key === key); }
 test('versionConstraint', () => {
   assert.strictEqual(versionConstraint('3.6.5'), '>=3.6.5');
   assert.strictEqual(versionConstraint(null), '*');
+});
+
+test('isComposerVersion accepts composer-legal versions, rejects WP dev headers', () => {
+  for (const v of ['10.7.0', '1.2', '3.6.5.1', '4.0.0-beta2', '4.0.0-RC1', '2.0.0-patch3']) {
+    assert.ok(isComposerVersion(v), `should accept ${v}`);
+  }
+  for (const v of ['4.0.0-dev2', 'dev-trunk', '4.0.x-dev', 'nightly', '', null]) {
+    assert.ok(!isComposerVersion(v), `should reject ${v}`);
+  }
+});
+
+test('unparseable header version falls back to resolver version (never emits a bad constraint)', async () => {
+  const treeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'tree-'));
+  fs.mkdirSync(path.join(treeRoot, 'plugins', 'official-facebook-pixel'), { recursive: true });
+  fs.writeFileSync(path.join(treeRoot, 'plugins', 'official-facebook-pixel', 'facebook.php'),
+    '<?php /* Plugin Name: FB\nVersion: 4.0.0-dev2 */'); // composer-illegal header
+  const items = [{ path: 'plugins/official-facebook-pixel/facebook.php', side: 'remote-only' }];
+  const out = await classify(items, { resolvers, treeRoot });
+  const c = findKey(out, 'official-facebook-pixel');
+  assert.strictEqual(c.recoverable, true);
+  assert.strictEqual(c.version, '3.0.0'); // resolver's published version, not the dev header
+  assert.strictEqual(versionConstraint(c.version), '>=3.0.0');
 });
 
 test('wpackagist plugin -> recoverable composer add (version from tree header when present)', async () => {


### PR DESCRIPTION
Follow-up to #10 — the diagnostics it added revealed the two *actual* bugs behind the blanket `version-unavailable`:

**1. HTTP 401 on `packages.saucal.com`.** Composer loads **all** repo metadata on any update, so even a wpackagist-only add needs SatisPress auth. The `COMPOSER_AUTH` env var wasn't honored. Switched to the org's proven mechanism — `composer config --global --auth http-basic.<host> <key> <host>` in the action step (writes `auth.json`, read by every later composer call). Dropped the env-var path from index.js.

**2. `>=4.0.0-dev2` broke composer.json.** That's a WordPress header version — `dev2` isn't a legal composer stability suffix, so composer's parser rejected the whole file. `classify` now only pins to composer-parseable versions (`isComposerVersion`), falling back to the resolver's published version, else leaving it unpinned (`*`). We never emit a constraint composer rejects.

63 unit / 15 integration green.

Expected next run: woocommerce + w3-total-cache resolve → genuine ✅ Applied with a real composer.lock; payoneer resolves to its published version (the server's `4.0.0-dev2` dev build isn't published, so it may still show residual drift → a legit adoption candidate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)