### PR TITLE
Reconcile: drop inline SatisPress auth, rely on prepare-composer

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -166,15 +166,10 @@ runs:
         MANIFEST_PATH: ${{ steps.pre-build-consistency-check.outputs.bufferPath }}
         DIFF_PATH: ${{ steps.pre-build-consistency-check.outputs.diffPath }}
         RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-      run: |
-        # Authenticate composer against the private SatisPress repo the same way deployment does
-        # (global auth.json, read by every later composer call). composer loads ALL repo metadata
-        # on any update, so this is required even to add a wpackagist-only plugin.
-        if [ -n "$SATISPRESS_TOKEN" ]; then
-          host=$(printf '%s' "$SATISPRESS_URL" | sed -E 's,^https?://,,; s,/.*$,,')
-          composer config --global --auth "http-basic.$host" "$SATISPRESS_TOKEN" "$host"
-        fi
-        node "$GITHUB_ACTION_PATH/reconcile/index.js"
+      # Composer SatisPress auth is configured upstream by action-prepare-composer (run via
+      # action-bundle-prepare earlier in this same job), which writes source/auth.json. Every
+      # composer call the reconcile makes runs in source/ and reads it — no auth setup here.
+      run: node "$GITHUB_ACTION_PATH/reconcile/index.js"
 
     - name: Signal Failure to slack
       if: ${{ failure() }}


### PR DESCRIPTION
Removes the duplicated inline `composer config http-basic` from the reconcile step. Auth is now configured once by **action-prepare-composer** (run via action-bundle-prepare earlier in the **same job**), which writes `source/auth.json`; the reconcile step's composer calls run in `source/` and read it.

Depends on the paired PRs (action-prepare-composer #, action-bundle-prepare #, action-maintenance) being merged so satis_key reaches prepare-composer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)