### PR TITLE
Reconcile rung 3: auth-gated adoption of non-composer plugins

### DIFF
--- a/reconcile/index.js
+++ b/reconcile/index.js
@@ -42,6 +42,7 @@ async function sh(cmd, args, opts = {}) {
   const runUrl = env('RUN_URL');
   const satispressUrl = env('SATISPRESS_URL');
   const satispressToken = env('SATISPRESS_TOKEN');
+  const adopt = /^(1|true)$/i.test(env('ADOPT_NON_COMPOSER'));
   const branch = `reconciliation-${ref}`;
   // Composer SatisPress auth is configured by the action step (composer config --global --auth)
   // before this script runs, so every composer subprocess here reads it from auth.json.
@@ -72,7 +73,7 @@ async function sh(cmd, args, opts = {}) {
   const runner = makeRunner();
   let result;
   try {
-    result = await reconcileRun({ sourceDir, treeRoot, manifestText, contentDiffText, resolvers, runner });
+    result = await reconcileRun({ sourceDir, treeRoot, manifestText, contentDiffText, resolvers, runner, adopt });
   } catch (e) {
     core.setFailed(`reconcile-run failed: ${e.stack || e}`);
     return;
@@ -101,6 +102,11 @@ async function sh(cmd, args, opts = {}) {
   const OUTPUT_PATHS = ['composer.json', 'composer.lock', 'patches', 'patches.lock.json', '.patches_applied'];
   const toStage = OUTPUT_PATHS.filter((p) => fs.existsSync(path.join(cwd, p)));
   if (toStage.length) await sh('git', ['add', '--', ...toStage], { cwd });
+  // Force-add adopted (vendored) component dirs — plugins/ is typically gitignored for
+  // composer-managed installs, so a plain `git add` would skip the newly-vendored source.
+  for (const root of (result.adoptedPaths || [])) {
+    await sh('git', ['add', '-f', '--', root], { cwd });
+  }
   const staged = await sh('git', ['diff', '--cached', '--name-only'], { cwd });
   if (!staged.out.trim()) {
     await core.summary.addRaw(body).write();

--- a/reconcile/lib/adopt.js
+++ b/reconcile/lib/adopt.js
@@ -1,0 +1,45 @@
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Vendor a component's server files into the source repo — the last-resort recovery for a
+ * plugin/theme available on neither wpackagist nor SatisPress. Copies treeRoot/<root> ->
+ * sourceDir/<root>, skipping any file whose repo-relative path is sensitive (never vendor
+ * credentials). The whole server dir is copied, not just drifted files, so the deploy
+ * reproduces the plugin in full.
+ *
+ * @param {object} o
+ * @param {string} o.sourceDir   composer project root
+ * @param {string} o.treeRoot    server-state tree
+ * @param {string} o.root        repo-relative component root (e.g. plugins/<slug>)
+ * @param {(relPath:string)=>boolean} [o.isSensitive]  predicate on repo-relative paths to skip
+ * @returns {{files:number, skipped:number, root:string}}
+ */
+function adoptComponent(o) {
+  const from = path.join(o.treeRoot, o.root);
+  if (!fs.existsSync(from)) throw new Error(`adopt: server dir not found: ${from}`);
+  const to = path.join(o.sourceDir, o.root);
+  fs.rmSync(to, { recursive: true, force: true });
+
+  let files = 0;
+  let skipped = 0;
+  const walk = (relDir) => {
+    const srcDir = path.join(o.treeRoot, o.root, relDir);
+    for (const e of fs.readdirSync(srcDir, { withFileTypes: true })) {
+      const rel = path.join(o.root, relDir, e.name); // repo-relative path
+      const s = path.join(srcDir, e.name);
+      if (e.isDirectory()) { walk(path.join(relDir, e.name)); continue; }
+      if (o.isSensitive && o.isSensitive(rel)) { skipped++; continue; }
+      const d = path.join(o.sourceDir, rel);
+      fs.mkdirSync(path.dirname(d), { recursive: true });
+      if (e.isSymbolicLink()) fs.symlinkSync(fs.readlinkSync(s), d);
+      else fs.copyFileSync(s, d);
+      files++;
+    }
+  };
+  walk('');
+  return { files, skipped, root: o.root };
+}
+
+module.exports = { adoptComponent };

--- a/reconcile/lib/classify.js
+++ b/reconcile/lib/classify.js
@@ -109,7 +109,8 @@ async function componentVerdict(comp, ctx) {
   }
 
   return { key: comp.slug, category: 'premium-flag', recoverable: false,
-    remediation: `Premium/unknown ${label}${treeVersion ? ` v${treeVersion}` : ''} on server, not on wpackagist or SatisPress. Add to SatisPress or vendor manually.` };
+    root: comp.root, kind: comp.kind,
+    remediation: `Premium/unknown ${label}${treeVersion ? ` v${treeVersion}` : ''} on server, not on wpackagist or SatisPress. Add to SatisPress or vendor into the repo.` };
 }
 
 module.exports = { classify, versionConstraint, isComposerVersion };

--- a/reconcile/lib/reconcile-run.js
+++ b/reconcile/lib/reconcile-run.js
@@ -7,6 +7,8 @@ const { classify, versionConstraint } = require('./classify');
 const { upsertRequire, removeRequire, ensureCweagansSetup, serializeComposer } = require('./composer');
 const { decideOutcome } = require('./outcome');
 const { reconcilePatched } = require('./reconcile-patched');
+const { adoptComponent } = require('./adopt');
+const { isSensitive } = require('./detectors');
 
 /**
  * Orchestrator core (no git/gh). Classifies drift and applies recoverable changes to the
@@ -140,9 +142,53 @@ async function reconcileRun(o) {
     applied.push(`patched:${c.key}:${res.action}`);
   }
 
+  // Pass 3 — adoption (opt-in via o.adopt). A component on neither wpackagist nor SatisPress can't
+  // be recovered through composer; as a last resort, vendor its server files into the repo so a
+  // deploy reproduces them. Auth-gated: only after the authenticated composer authoritatively
+  // confirms the package is unavailable (guards against a resolver false-negative), and sensitive
+  // files are never copied.
+  const adoptedPaths = [];
+  if (o.adopt) {
+    for (const c of classified) {
+      if (c.category !== 'premium-flag') continue;
+      const root = c.root || `plugins/${c.key}`;
+
+      // Authoritative re-check: if composer (authenticated) can see any candidate package, this is
+      // NOT an adoption case — it should be a composer add. Skip so we never fork a resolvable plugin.
+      if (o.runner) {
+        const names = [`wpackagist-plugin/${c.key}`, `wpackagist-theme/${c.key}`, `saucal/${c.key}`];
+        let resolvable = false;
+        for (const n of names) {
+          const s = await o.runner.composer(['show', n, '--all', '--no-interaction'], { cwd: o.sourceDir });
+          if (s.code === 0) { resolvable = true; break; }
+        }
+        if (resolvable) {
+          c.remediation = `${c.key} resolves via composer after all — re-run to add it via composer instead of vendoring.`;
+          applied.push(`adopt:${c.key}:skipped-resolvable`);
+          continue;
+        }
+      }
+
+      try {
+        const res = adoptComponent({ sourceDir: o.sourceDir, treeRoot: o.treeRoot, root, isSensitive });
+        c.category = res.skipped > 0 ? 'adopted-lossy' : 'adopted';
+        c.recoverable = true;
+        c.adoptedRoot = root;
+        c.remediation = res.skipped > 0
+          ? `Vendored ${c.key} into the repo (${res.files} files); ${res.skipped} sensitive file(s) skipped — review whether they matter.`
+          : `Vendored ${c.key} into the repo (${res.files} files) — not available on wpackagist/SatisPress.`;
+        adoptedPaths.push(root);
+        applied.push(`adopt:${c.key}`);
+      } catch (e) {
+        c.remediation = `Adoption failed for ${c.key}: ${e.message}`;
+        applied.push(`adopt:${c.key}:failed`);
+      }
+    }
+  }
+
   // Compute outcome last so the cweagans downgrade is reflected.
   const outcome = decideOutcome(classified);
-  return { classified, outcome, applied };
+  return { classified, outcome, applied, adoptedPaths };
 }
 
 /** Pull the most informative line out of composer's error output for a one-line reason. */

--- a/reconcile/lib/report.js
+++ b/reconcile/lib/report.js
@@ -9,8 +9,10 @@ const { decideOutcome } = require('./outcome');
 function reportBody(classified, meta) {
   const outcome = decideOutcome(classified);
   const isPatched = (c) => c.category === 'patched' || c.category === 'patched-candidate';
-  const applied = classified.filter((c) => c.recoverable && !isPatched(c));
+  const isAdopted = (c) => c.category === 'adopted' || c.category === 'adopted-lossy';
+  const applied = classified.filter((c) => c.recoverable && !isPatched(c) && !isAdopted(c));
   const patched = classified.filter(isPatched);
+  const adopted = classified.filter(isAdopted);
   const ignorable = classified.filter((c) => c.category === 'ignorable');
   const unrecoverable = classified.filter((c) => c.category === 'compiled-asset' || c.category === 'sensitive');
   const needsReview = classified.filter((c) =>
@@ -25,6 +27,7 @@ function reportBody(classified, meta) {
   L.push('');
   pushSection(L, '✅ Applied (in this PR)', applied, (c) => `\`${c.composerPackage || c.key}\` — ${c.remediation}`);
   pushSection(L, '🩹 Patched (modified from published)', patched, (c) => `\`${c.composerPackage || c.key}\` — ${c.remediation}`);
+  pushSection(L, '📦 Adopted (vendored into repo)', adopted, (c) => `\`${c.key}\` — ${c.remediation}`);
   pushSection(L, '⚠️ Needs review', needsReview, (c) => `\`${c.key}\` — ${c.remediation}`);
   pushSection(L, '🧹 Ignorable (no source change)', ignorable, (c) => `\`${c.key}\` — ${c.remediation}`);
   pushSection(L, '⛔ Unrecoverable', unrecoverable, (c) => `\`${c.key}\` — ${c.remediation}`);

--- a/reconcile/test/adopt.test.js
+++ b/reconcile/test/adopt.test.js
@@ -1,0 +1,51 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { adoptComponent } = require('../lib/adopt');
+
+function mktmp(p) { return fs.mkdtempSync(path.join(os.tmpdir(), p)); }
+
+test('adoptComponent copies the whole server component dir into source', () => {
+  const server = mktmp('srv-');
+  const src = mktmp('src-');
+  fs.mkdirSync(path.join(server, 'plugins/foo/inc'), { recursive: true });
+  fs.writeFileSync(path.join(server, 'plugins/foo/foo.php'), '<?php // foo');
+  fs.writeFileSync(path.join(server, 'plugins/foo/inc/lib.php'), '<?php // lib');
+  const res = adoptComponent({ sourceDir: src, treeRoot: server, root: 'plugins/foo' });
+  assert.strictEqual(res.files, 2);
+  assert.strictEqual(res.skipped, 0);
+  assert.ok(fs.existsSync(path.join(src, 'plugins/foo/foo.php')));
+  assert.ok(fs.existsSync(path.join(src, 'plugins/foo/inc/lib.php')));
+});
+
+test('adoptComponent skips sensitive files (never vendor credentials)', () => {
+  const server = mktmp('srv-'); const src = mktmp('src-');
+  fs.mkdirSync(path.join(server, 'plugins/foo'), { recursive: true });
+  fs.writeFileSync(path.join(server, 'plugins/foo/foo.php'), '<?php');
+  fs.writeFileSync(path.join(server, 'plugins/foo/secret-credentials.php'), '<?php return ["k"=>"v"];');
+  const isSensitive = (rel) => /credentials/.test(rel);
+  const res = adoptComponent({ sourceDir: src, treeRoot: server, root: 'plugins/foo', isSensitive });
+  assert.strictEqual(res.files, 1);
+  assert.strictEqual(res.skipped, 1);
+  assert.ok(fs.existsSync(path.join(src, 'plugins/foo/foo.php')));
+  assert.ok(!fs.existsSync(path.join(src, 'plugins/foo/secret-credentials.php')), 'sensitive file not vendored');
+});
+
+test('adoptComponent throws when the server dir is missing', () => {
+  const src = mktmp('src-');
+  assert.throws(() => adoptComponent({ sourceDir: src, treeRoot: '/nonexistent', root: 'plugins/x' }));
+});
+
+test('adoptComponent replaces an existing dir cleanly (removes stale files)', () => {
+  const server = mktmp('srv-'); const src = mktmp('src-');
+  fs.mkdirSync(path.join(server, 'plugins/foo'), { recursive: true });
+  fs.writeFileSync(path.join(server, 'plugins/foo/new.php'), 'new');
+  fs.mkdirSync(path.join(src, 'plugins/foo'), { recursive: true });
+  fs.writeFileSync(path.join(src, 'plugins/foo/old.php'), 'old');
+  adoptComponent({ sourceDir: src, treeRoot: server, root: 'plugins/foo' });
+  assert.ok(fs.existsSync(path.join(src, 'plugins/foo/new.php')));
+  assert.ok(!fs.existsSync(path.join(src, 'plugins/foo/old.php')), 'stale file removed');
+});

--- a/reconcile/test/integration/scenarios.integration.test.js
+++ b/reconcile/test/integration/scenarios.integration.test.js
@@ -425,6 +425,34 @@ test('unavailable: server version exceeds anything published -> flagged, compose
   assert.ok(res.applied.includes('require:saucal/futureplug:unavailable'), `applied: ${res.applied}`);
 });
 
+// --- 12. adopt: unresolvable premium plugin vendored into source --------
+test('adopt: plugin on neither wpackagist nor SatisPress -> vendored into source (flag on)', async () => {
+  const { dir } = makeProject({
+    plugins: [{ slug: 'baseplug', pkg: 'saucal/baseplug', version: '1.0.0', body: '// base\n' }],
+  });
+  // Nothing resolves — the plugin is genuinely unknown to composer (no path repo for it).
+  const resolvers = { async wpackagist() { return null; }, async satispress() { return null; } };
+
+  const serverDir = stageServer(dir, (sv) => {
+    const d = path.join(sv, 'plugins/premiumx');
+    fs.mkdirSync(path.join(d, 'inc'), { recursive: true });
+    fs.writeFileSync(path.join(d, 'premiumx.php'), '<?php\n/* Plugin Name: premiumx */\n// premium code\n');
+    fs.writeFileSync(path.join(d, 'inc/helper.php'), '<?php // helper\n');
+  });
+
+  const { manifestText, contentDiffText } = deriveDrift(dir, serverDir);
+  const res = await reconcileRun({
+    sourceDir: dir, treeRoot: serverDir, manifestText, contentDiffText,
+    resolvers, runner: makeRunner(), adopt: true,
+  });
+
+  const c = findByKey(res.classified, 'premiumx');
+  assert.strictEqual(c.category, 'adopted', `category: ${c && c.category}`);
+  assert.ok(fs.existsSync(path.join(dir, 'plugins/premiumx/premiumx.php')), 'vendored main file');
+  assert.ok(fs.existsSync(path.join(dir, 'plugins/premiumx/inc/helper.php')), 'vendored nested file');
+  assert.ok(res.adoptedPaths.includes('plugins/premiumx'), `adoptedPaths: ${res.adoptedPaths}`);
+});
+
 // --- 10. bootstrap cweagans on a repo that lacks it ---------------------
 test('bootstrap: repo without cweagans gets it installed + the plugin patched', async () => {
   const { dir } = makeProject({

--- a/reconcile/test/reconcile-run.test.js
+++ b/reconcile/test/reconcile-run.test.js
@@ -96,6 +96,67 @@ test('flag-only: sensitive item leaves composer untouched, no runner call, empty
   assert.deepStrictEqual(res.applied, []);
 });
 
+// Server tree carrying an unresolvable "premium" plugin (on neither wpackagist nor satispress).
+function premiumTree() {
+  const treeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'tree-'));
+  fs.mkdirSync(path.join(treeRoot, 'plugins', 'premiumplug'), { recursive: true });
+  fs.writeFileSync(path.join(treeRoot, 'plugins', 'premiumplug', 'premiumplug.php'), '<?php // premium\n');
+  return treeRoot;
+}
+const noResolve = { async wpackagist() { return null; }, async satispress() { return null; } };
+const premiumManifest = 'deleting plugins/premiumplug/premiumplug.php\n';
+
+test('adopt: premium-flag component is vendored into source when the flag is on', async () => {
+  const sourceDir = tmpSource();
+  const treeRoot = premiumTree();
+  // composer `show` returns nonzero (not resolvable) so adoption proceeds; other calls succeed.
+  const runner = { calls: [], composer(args) { this.calls.push(args); return { code: args[0] === 'show' ? 1 : 0, stdout: '', stderr: '' }; } };
+
+  const res = await reconcileRun({ sourceDir, treeRoot, manifestText: premiumManifest, resolvers: noResolve, runner, adopt: true });
+
+  const c = res.classified.find((x) => x.key === 'premiumplug');
+  assert.strictEqual(c.category, 'adopted');
+  assert.strictEqual(c.recoverable, true);
+  assert.ok(fs.existsSync(path.join(sourceDir, 'plugins/premiumplug/premiumplug.php')), 'vendored into source');
+  assert.deepStrictEqual(res.adoptedPaths, ['plugins/premiumplug']);
+  assert.ok(res.applied.includes('adopt:premiumplug'), res.applied.join(','));
+});
+
+test('adopt: off by default -> premium-flag stays flagged, nothing vendored', async () => {
+  const sourceDir = tmpSource();
+  const treeRoot = premiumTree();
+  const res = await reconcileRun({ sourceDir, treeRoot, manifestText: premiumManifest, resolvers: noResolve, runner: fakeRunner() });
+
+  const c = res.classified.find((x) => x.key === 'premiumplug');
+  assert.strictEqual(c.category, 'premium-flag');
+  assert.strictEqual(c.recoverable, false);
+  assert.ok(!fs.existsSync(path.join(sourceDir, 'plugins/premiumplug/premiumplug.php')));
+  assert.deepStrictEqual(res.adoptedPaths, []);
+});
+
+test('adopt: composer show finds the package -> skip vendoring (would fork a resolvable plugin)', async () => {
+  const sourceDir = tmpSource();
+  const treeRoot = premiumTree();
+  // `show` returns 0 => package IS resolvable => must not vendor.
+  const runner = { calls: [], composer(args) { this.calls.push(args); return { code: 0, stdout: '', stderr: '' }; } };
+
+  const res = await reconcileRun({ sourceDir, treeRoot, manifestText: premiumManifest, resolvers: noResolve, runner, adopt: true });
+
+  const c = res.classified.find((x) => x.key === 'premiumplug');
+  assert.strictEqual(c.category, 'premium-flag', 'unchanged — not adopted');
+  assert.ok(!fs.existsSync(path.join(sourceDir, 'plugins/premiumplug/premiumplug.php')));
+  assert.ok(res.applied.includes('adopt:premiumplug:skipped-resolvable'), res.applied.join(','));
+});
+
+test('adopt: a sensitive component is never adopted (stays flagged), even with the flag on', async () => {
+  const sourceDir = tmpSource();
+  // credentials mu-plugin drift classifies as `sensitive`, not `premium-flag`.
+  const res = await reconcileRun({ sourceDir, treeRoot: '/nonexistent', manifestText: 'deleting plugins/spy/secret-credentials.php\n', resolvers: noResolve, runner: fakeRunner(), adopt: true });
+  const c = res.classified.find((x) => x.key === 'spy');
+  assert.strictEqual(c.category, 'sensitive');
+  assert.deepStrictEqual(res.adoptedPaths, []);
+});
+
 test('no cweagans: a modified-from-published plugin BOOTSTRAPS the patch setup, then patches', async () => {
   const sourceDir = tmpSource(); // composer.json has require {} — no cweagans/composer-patches
   // Pristine installed copy (so reconcile-patched's generatePatch has a real dir to diff).


### PR DESCRIPTION
The last-resort reconcile path: when a drifted plugin/theme is on **neither** wpackagist **nor** SatisPress, vendor its server files into the repo and let the deploy reproduce them — the only way to bring an unfulfillable plugin to sync. Opt-in via the existing `reconcile-adopt-non-composer` flag (`ADOPT_NON_COMPOSER`), **default off**.

## Guardrails
- **Auth-gated**: adopt only after the authenticated `composer show` confirms the package is genuinely unavailable — never fork a plugin that actually resolves (guards a resolver false-negative). This is why the auth work had to land first: the "not found" is now trustworthy.
- **Never vendor sensitive files**: scrubbed during the copy; if any are skipped → `adopted-lossy` for review.
- Only `premium-flag` components (unresolvable, no sensitive drift) are candidates. Sensitive-classified components are never auto-adopted.

## Wiring
- `lib/adopt.js` — copy component dir, skip sensitive files.
- reconcile-run Pass 3 — the gated adoption loop; returns `adoptedPaths`.
- `index.js` — `git add -f` the vendored dirs (`plugins/` is gitignored for composer installs).
- report — `📦 Adopted` section; adopted = recoverable.

**71 unit / 16 integration green** (incl. real-composer adoption + sensitive-scrub + skip-if-resolvable). Dormant behind the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)