### PR TITLE
classify: exclude vendor/ paths from the sensitive-file check

### DIFF
--- a/reconcile/lib/classify.js
+++ b/reconcile/lib/classify.js
@@ -98,7 +98,12 @@ async function componentVerdict(comp, ctx) {
 
   // Not resolvable to a package: only now consider flags. A sensitive-looking file bundled
   // inside a resolvable plugin must NOT block the add above — composer installs pristine.
-  if (comp.paths.some((it) => isSensitive(it.path))) {
+  // Exclude vendor/ paths from the sensitive check: bundled SDKs (AWS, Google Cloud, ...) ship
+  // dozens of legitimately-named `*Credentials.php` classes (credential-HANDLING code, not a
+  // secret file) which would otherwise false-positive every cloud-storage plugin as "sensitive"
+  // and permanently block it from adoption. A real secrets file directly in the component
+  // (not vendor/) still flags.
+  if (comp.paths.some((it) => isSensitive(it.path) && !isVendorPath(it.path))) {
     return { key: comp.slug, category: 'sensitive', recoverable: false,
       remediation: `Sensitive file inside ${label}, which is not resolvable to a package. Review manually.` };
   }

--- a/reconcile/test/classify.test.js
+++ b/reconcile/test/classify.test.js
@@ -146,3 +146,27 @@ test('non-resolvable plugin with a sensitive file is still flagged sensitive', a
   assert.strictEqual(c.category, 'sensitive');
   assert.strictEqual(c.recoverable, false);
 });
+
+test('vendor SDK "Credentials" classes are NOT sensitive (false-positive regression: amazon-s3-and-cloudfront-pro)', async () => {
+  // Real-world shape: a cloud-storage plugin bundles the AWS/GCP SDK under vendor/, whose
+  // class files are legitimately named *Credentials.php (credential-HANDLING code, not a
+  // secret). Non-vendor plugin files are also present, so with the false positive gone this
+  // should fall through to premium-flag (an adoption candidate), not sensitive.
+  const out = await classify([
+    { path: 'plugins/amazon-s3-and-cloudfront-pro/vendor/Aws3/Aws/Credentials/CredentialsInterface.php', side: 'remote-only' },
+    { path: 'plugins/amazon-s3-and-cloudfront-pro/vendor/Gcp/google/auth/src/Credentials/GCECredentials.php', side: 'remote-only' },
+    { path: 'plugins/amazon-s3-and-cloudfront-pro/view/settings.php', side: 'remote-only' },
+  ], { resolvers, treeRoot: '/nonexistent' });
+  const c = findKey(out, 'amazon-s3-and-cloudfront-pro');
+  assert.strictEqual(c.category, 'premium-flag', `expected premium-flag, got ${c.category}`);
+});
+
+test('a real secrets file directly in a component (not vendor/) still flags sensitive even alongside vendor noise', async () => {
+  const out = await classify([
+    { path: 'plugins/leakyplug/vendor/Aws3/Aws/Credentials/Credentials.php', side: 'remote-only' },
+    { path: 'plugins/leakyplug/wp-config-backup.php', side: 'remote-only' },
+  ], { resolvers, treeRoot: '/nonexistent' });
+  const c = findKey(out, 'leakyplug');
+  assert.strictEqual(c.category, 'sensitive');
+  assert.strictEqual(c.recoverable, false);
+});


### PR DESCRIPTION
Live investigation of why \`amazon-s3-and-cloudfront-pro\` never adopts on ci-test-ftp: it's permanently flagged \`sensitive\`, and the trigger is a **false positive**.

## Root cause
All 34 sensitive-matching lines in the live drift manifest are inside \`vendor/Aws3/...\` and \`vendor/Gcp/...\` — the plugin's bundled (namespace-prefixed) copies of the **AWS SDK for PHP** and **Google Cloud SDK**. Every match is a class legitimately named \`*Credentials.php\` (\`CredentialsInterface.php\`, \`GCECredentials.php\`, \`CredentialsWrapper.php\`, ...) — credential-**handling** code, not a file containing a secret. Zero matches occur outside \`vendor/\`.

Any plugin bundling these SDKs (any S3/GCS-integrating plugin) trips the same false positive, and since the sensitive check runs before the vendor/compiled-asset check, it permanently misclassifies the whole plugin — blocking both a normal composer add *and* rung-3 adoption.

## Fix
Exclude \`vendor/\` paths from the sensitive check (\`isVendorPath\` already exists, used by the compiled-asset check for this exact class of file). A real secrets file directly in the component (not vendor/) still flags correctly — covered by a regression test alongside the false-positive one.

With this, \`amazon-s3-and-cloudfront-pro\` reclassifies as \`premium-flag\` — the category rung-3 adoption acts on. No behavior change to the live PR until \`reconcile-adopt-non-composer\` is enabled separately.

**73 unit / 16 integration green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)