### PR TITLE
resolvers: route SatisPress resolution through composer (eliminate duplicate auth)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -82,11 +82,11 @@ inputs:
     required: false
     default: ''
   satispress-url:
-    description: "SatisPress composer repo base URL, used to resolve premium plugins."
+    description: "Deprecated, no longer read. SatisPress resolution now goes through composer itself (composer show), authenticated via the auth.json action-composer-auth configures upstream in this job. Kept only for backward compatibility with existing callers."
     required: false
     default: 'https://packages.saucal.com'
   satispress-token:
-    description: "SatisPress HTTP Basic auth token (license key) used to resolve premium plugins."
+    description: "Deprecated, no longer read. See satispress-url."
     required: false
     default: ''
   reconcile-adopt-non-composer:
@@ -160,8 +160,6 @@ runs:
         REF: ${{ github.ref_name }}
         SOURCE_DIR: ${{ inputs.source }}
         BUILT_DIR: ${{ inputs.built }}
-        SATISPRESS_URL: ${{ inputs.satispress-url }}
-        SATISPRESS_TOKEN: ${{ inputs.satispress-token }}
         ADOPT_NON_COMPOSER: ${{ inputs.reconcile-adopt-non-composer }}
         MANIFEST_PATH: ${{ steps.pre-build-consistency-check.outputs.bufferPath }}
         DIFF_PATH: ${{ steps.pre-build-consistency-check.outputs.diffPath }}

--- a/reconcile/index.js
+++ b/reconcile/index.js
@@ -69,7 +69,15 @@ async function sh(cmd, args, opts = {}) {
   if (checkedOut.code !== 0) { core.setFailed(`git checkout failed:\n${checkedOut.out}`); return; }
 
   // 2. Classify + apply (composer add/bump + patches) via the orchestrator core.
-  const resolvers = makeResolvers(fetch, satispressUrl, satispressToken);
+  // SatisPress Basic auth password must match what composer itself uses (action-composer-auth /
+  // build-for-deployment.sh: the project's `homepage`, protocol stripped) — otherwise this
+  // resolver silently 401s and misclassifies an available package as unresolvable.
+  let satispressPassword = '';
+  if (satispressToken) {
+    const hp = await sh('composer', ['config', 'homepage'], { cwd });
+    if (hp.code === 0) satispressPassword = hp.out.trim().replace(/^https?:\/\//, '');
+  }
+  const resolvers = makeResolvers(fetch, satispressUrl, satispressToken, satispressPassword);
   const runner = makeRunner();
   let result;
   try {

--- a/reconcile/index.js
+++ b/reconcile/index.js
@@ -40,8 +40,6 @@ async function sh(cmd, args, opts = {}) {
   const manifestPath = env('MANIFEST_PATH');
   const diffPath = env('DIFF_PATH');
   const runUrl = env('RUN_URL');
-  const satispressUrl = env('SATISPRESS_URL');
-  const satispressToken = env('SATISPRESS_TOKEN');
   const adopt = /^(1|true)$/i.test(env('ADOPT_NON_COMPOSER'));
   const branch = `reconciliation-${ref}`;
   // Composer SatisPress auth is configured by the action step (composer config --global --auth)
@@ -69,16 +67,11 @@ async function sh(cmd, args, opts = {}) {
   if (checkedOut.code !== 0) { core.setFailed(`git checkout failed:\n${checkedOut.out}`); return; }
 
   // 2. Classify + apply (composer add/bump + patches) via the orchestrator core.
-  // SatisPress Basic auth password must match what composer itself uses (action-composer-auth /
-  // build-for-deployment.sh: the project's `homepage`, protocol stripped) — otherwise this
-  // resolver silently 401s and misclassifies an available package as unresolvable.
-  let satispressPassword = '';
-  if (satispressToken) {
-    const hp = await sh('composer', ['config', 'homepage'], { cwd });
-    if (hp.code === 0) satispressPassword = hp.out.trim().replace(/^https?:\/\//, '');
-  }
-  const resolvers = makeResolvers(fetch, satispressUrl, satispressToken, satispressPassword);
+  // SatisPress resolution goes through composer itself (`composer show`), reusing the SAME
+  // auth.json action-composer-auth already configured earlier in this job — no separate
+  // credential handling for the resolver.
   const runner = makeRunner();
+  const resolvers = makeResolvers({ fetch, runner, cwd });
   let result;
   try {
     result = await reconcileRun({ sourceDir, treeRoot, manifestText, contentDiffText, resolvers, runner, adopt });

--- a/reconcile/lib/resolvers.js
+++ b/reconcile/lib/resolvers.js
@@ -4,8 +4,13 @@
  * @param {typeof fetch} f       injectable fetch (defaults to global)
  * @param {string} satispressUrl base URL of the SatisPress composer repo ('' disables it)
  * @param {string} satispressToken optional HTTP Basic auth token (license key)
+ * @param {string} [satispressPassword] HTTP Basic auth password. Must match the convention
+ *   composer itself uses (action-composer-auth / build-for-deployment.sh): the project's
+ *   composer.json `homepage`, protocol stripped — NOT empty. A mismatch here silently 401s
+ *   every SatisPress lookup, misclassifying an available package as unresolvable
+ *   ("premium-flag") instead of a normal add.
  */
-function makeResolvers(f = fetch, satispressUrl = '', satispressToken = '') {
+function makeResolvers(f = fetch, satispressUrl = '', satispressToken = '', satispressPassword = '') {
   async function wpackagist(kind, slug) {
     const url = `https://api.wordpress.org/${kind}s/info/1.0/${slug}.json`;
     try {
@@ -23,11 +28,10 @@ function makeResolvers(f = fetch, satispressUrl = '', satispressToken = '') {
     if (!satispressUrl) return null;
     const base = satispressUrl.replace(/\/$/, '');
     const url = `${base}/p2/saucal/${slug}.json`;
-    // SatisPress requires HTTP Basic auth. Exact user:pass must be confirmed before
-    // production (the build action uses `composer config http-basic.<host> <SATIS_KEY> ...`);
-    // here we send base64(token:) as a best effort and degrade to null (flag) on failure.
+    // SatisPress requires HTTP Basic auth: username = token, password = project homepage
+    // (matches composer's own auth.json, configured by action-composer-auth).
     const opts = satispressToken
-      ? { headers: { Authorization: `Basic ${Buffer.from(`${satispressToken}:`).toString('base64')}` } }
+      ? { headers: { Authorization: `Basic ${Buffer.from(`${satispressToken}:${satispressPassword}`).toString('base64')}` } }
       : undefined;
     try {
       const r = await f(url, opts);

--- a/reconcile/lib/resolvers.js
+++ b/reconcile/lib/resolvers.js
@@ -1,16 +1,17 @@
 'use strict';
 
 /**
- * @param {typeof fetch} f       injectable fetch (defaults to global)
- * @param {string} satispressUrl base URL of the SatisPress composer repo ('' disables it)
- * @param {string} satispressToken optional HTTP Basic auth token (license key)
- * @param {string} [satispressPassword] HTTP Basic auth password. Must match the convention
- *   composer itself uses (action-composer-auth / build-for-deployment.sh): the project's
- *   composer.json `homepage`, protocol stripped — NOT empty. A mismatch here silently 401s
- *   every SatisPress lookup, misclassifying an available package as unresolvable
- *   ("premium-flag") instead of a normal add.
+ * @param {object} o
+ * @param {typeof fetch} [o.fetch] injectable fetch for the public wpackagist lookup (defaults to global)
+ * @param {object} [o.runner]     makeRunner()-shaped { composer(args,{cwd}) }, used for satispress.
+ *   Required to resolve satispress at all — no runner means satispress() always returns null.
+ * @param {string} [o.cwd]        composer project dir (has composer.json + the satispress repo
+ *   entry + auth.json, already configured upstream by action-composer-auth in this job)
  */
-function makeResolvers(f = fetch, satispressUrl = '', satispressToken = '', satispressPassword = '') {
+function makeResolvers(o = {}) {
+  const f = o.fetch || fetch;
+  const { runner, cwd = '.' } = o;
+
   async function wpackagist(kind, slug) {
     const url = `https://api.wordpress.org/${kind}s/info/1.0/${slug}.json`;
     try {
@@ -24,25 +25,22 @@ function makeResolvers(f = fetch, satispressUrl = '', satispressToken = '', sati
     }
   }
 
+  // Resolves through composer itself (`composer show`) rather than a hand-rolled HTTP call —
+  // reuses the SAME auth.json action-composer-auth already configured in this job, so there is
+  // exactly one place SatisPress credentials are ever handled. (A prior direct-fetch + guessed
+  // Basic-auth implementation silently 401'd on every real lookup; see git history.)
   async function satispress(slug) {
-    if (!satispressUrl) return null;
-    const base = satispressUrl.replace(/\/$/, '');
-    const url = `${base}/p2/saucal/${slug}.json`;
-    // SatisPress requires HTTP Basic auth: username = token, password = project homepage
-    // (matches composer's own auth.json, configured by action-composer-auth).
-    const opts = satispressToken
-      ? { headers: { Authorization: `Basic ${Buffer.from(`${satispressToken}:${satispressPassword}`).toString('base64')}` } }
-      : undefined;
-    try {
-      const r = await f(url, opts);
-      if (!r.ok) return null;
-      const j = await r.json();
-      const versions = j && j.packages && j.packages[`saucal/${slug}`];
-      if (!Array.isArray(versions) || versions.length === 0) return null;
-      return { source: 'satispress', package: `saucal/${slug}`, version: versions[0].version };
-    } catch {
-      return null;
-    }
+    if (!runner) return null;
+    const pkg = `saucal/${slug}`;
+    const r = await runner.composer(['show', pkg, '--all', '--format=json'], { cwd });
+    if (r.code !== 0) return null;
+    let data;
+    try { data = JSON.parse(r.stdout || '{}'); } catch { return null; }
+    const versions = Array.isArray(data.versions) ? data.versions : [];
+    // Skip dev/branch-alias entries (e.g. "3.x-dev") for a concrete version to pin.
+    const stable = versions.find((v) => typeof v === 'string' && !/-dev$|^dev-/i.test(v));
+    if (!stable) return null;
+    return { source: 'satispress', package: pkg, version: stable };
   }
 
   return { wpackagist, satispress };

--- a/reconcile/test/resolvers.test.js
+++ b/reconcile/test/resolvers.test.js
@@ -41,7 +41,7 @@ test('satispress returns null when url is empty', async () => {
   assert.strictEqual(await satispress('anything'), null);
 });
 
-test('satispress sends Authorization header when a token is provided', async () => {
+test('satispress sends Authorization header with an empty password when none is provided', async () => {
   let seenOpts;
   const url = 'https://packages.saucal.com/p2/saucal/churn-solution.json';
   const f = async (u, opts) => {
@@ -55,4 +55,18 @@ test('satispress sends Authorization header when a token is provided', async () 
   assert.ok(seenOpts && seenOpts.headers && seenOpts.headers.Authorization.startsWith('Basic '));
   const decoded = Buffer.from(seenOpts.headers.Authorization.slice('Basic '.length), 'base64').toString();
   assert.strictEqual(decoded, 'SECRET_KEY:');
+});
+
+test('satispress uses the given password (matches composer auth.json convention: token:homepage)', async () => {
+  let seenOpts;
+  const url = 'https://packages.saucal.com/p2/saucal/churn-solution.json';
+  const f = async (u, opts) => {
+    seenOpts = opts;
+    if (u !== url) return { ok: false, status: 404, json: async () => ({}) };
+    return { ok: true, status: 200, json: async () => ({ packages: { 'saucal/churn-solution': [{ version: '2.1.0' }] } }) };
+  };
+  const { satispress } = makeResolvers(f, 'https://packages.saucal.com', 'SECRET_KEY', 'example.com');
+  await satispress('churn-solution');
+  const decoded = Buffer.from(seenOpts.headers.Authorization.slice('Basic '.length), 'base64').toString();
+  assert.strictEqual(decoded, 'SECRET_KEY:example.com');
 });

--- a/reconcile/test/resolvers.test.js
+++ b/reconcile/test/resolvers.test.js
@@ -10,11 +10,16 @@ function fakeFetch(map) {
   };
 }
 
+function fakeRunner(handler) {
+  const calls = [];
+  return { calls, composer: async (args, opts) => { calls.push({ args, opts }); return handler(args, opts); } };
+}
+
 test('wpackagist resolves an existing plugin', async () => {
   const f = fakeFetch({
     'https://api.wordpress.org/plugins/info/1.0/code-snippets.json': { slug: 'code-snippets', version: '3.6.5' },
   });
-  const { wpackagist } = makeResolvers(f, '');
+  const { wpackagist } = makeResolvers({ fetch: f });
   assert.deepStrictEqual(await wpackagist('plugin', 'code-snippets'),
     { source: 'wpackagist-plugin', package: 'wpackagist-plugin/code-snippets', version: '3.6.5' });
 });
@@ -23,50 +28,41 @@ test('wpackagist returns null on 404 or error payload', async () => {
   const f = fakeFetch({
     'https://api.wordpress.org/plugins/info/1.0/nope.json': { error: 'Plugin not found.' },
   });
-  const { wpackagist } = makeResolvers(f, '');
+  const { wpackagist } = makeResolvers({ fetch: f });
   assert.strictEqual(await wpackagist('plugin', 'nope'), null);
   assert.strictEqual(await wpackagist('plugin', 'missing'), null);
 });
 
-test('satispress resolves from packages.saucal.com p2 metadata', async () => {
-  const url = 'https://packages.saucal.com/p2/saucal/churn-solution.json';
-  const f = fakeFetch({ [url]: { packages: { 'saucal/churn-solution': [{ version: '2.1.0' }] } } });
-  const { satispress } = makeResolvers(f, 'https://packages.saucal.com');
-  assert.deepStrictEqual(await satispress('churn-solution'),
-    { source: 'satispress', package: 'saucal/churn-solution', version: '2.1.0' });
-});
-
-test('satispress returns null when url is empty', async () => {
-  const { satispress } = makeResolvers(fakeFetch({}), '');
+test('satispress returns null when no runner is given', async () => {
+  const { satispress } = makeResolvers({ fetch: fakeFetch({}) });
   assert.strictEqual(await satispress('anything'), null);
 });
 
-test('satispress sends Authorization header with an empty password when none is provided', async () => {
-  let seenOpts;
-  const url = 'https://packages.saucal.com/p2/saucal/churn-solution.json';
-  const f = async (u, opts) => {
-    seenOpts = opts;
-    if (u !== url) return { ok: false, status: 404, json: async () => ({}) };
-    return { ok: true, status: 200, json: async () => ({ packages: { 'saucal/churn-solution': [{ version: '2.1.0' }] } }) };
-  };
-  const { satispress } = makeResolvers(f, 'https://packages.saucal.com', 'SECRET_KEY');
+test('satispress resolves via `composer show` (reuses the runner\'s own auth.json, no separate credential handling)', async () => {
+  const runner = fakeRunner((args) => {
+    assert.deepStrictEqual(args, ['show', 'saucal/churn-solution', '--all', '--format=json']);
+    return { code: 0, stdout: JSON.stringify({ versions: ['2.x-dev', '2.1.0', '2.0.0'] }), stderr: '' };
+  });
+  const { satispress } = makeResolvers({ runner, cwd: 'source' });
   const res = await satispress('churn-solution');
-  assert.strictEqual(res.version, '2.1.0');
-  assert.ok(seenOpts && seenOpts.headers && seenOpts.headers.Authorization.startsWith('Basic '));
-  const decoded = Buffer.from(seenOpts.headers.Authorization.slice('Basic '.length), 'base64').toString();
-  assert.strictEqual(decoded, 'SECRET_KEY:');
+  assert.deepStrictEqual(res, { source: 'satispress', package: 'saucal/churn-solution', version: '2.1.0' });
+  assert.strictEqual(runner.calls[0].opts.cwd, 'source');
 });
 
-test('satispress uses the given password (matches composer auth.json convention: token:homepage)', async () => {
-  let seenOpts;
-  const url = 'https://packages.saucal.com/p2/saucal/churn-solution.json';
-  const f = async (u, opts) => {
-    seenOpts = opts;
-    if (u !== url) return { ok: false, status: 404, json: async () => ({}) };
-    return { ok: true, status: 200, json: async () => ({ packages: { 'saucal/churn-solution': [{ version: '2.1.0' }] } }) };
-  };
-  const { satispress } = makeResolvers(f, 'https://packages.saucal.com', 'SECRET_KEY', 'example.com');
-  await satispress('churn-solution');
-  const decoded = Buffer.from(seenOpts.headers.Authorization.slice('Basic '.length), 'base64').toString();
-  assert.strictEqual(decoded, 'SECRET_KEY:example.com');
+test('satispress skips dev/branch-alias entries to find a concrete version', async () => {
+  const runner = fakeRunner(() => ({ code: 0, stdout: JSON.stringify({ versions: ['dev-main', '3.x-dev', '1.5.2'] }), stderr: '' }));
+  const { satispress } = makeResolvers({ runner });
+  assert.deepStrictEqual(await satispress('x'), { source: 'satispress', package: 'saucal/x', version: '1.5.2' });
+});
+
+test('satispress returns null when composer show fails (package not found / not configured)', async () => {
+  const runner = fakeRunner(() => ({ code: 1, stdout: '', stderr: 'Package "saucal/nope" not found.' }));
+  const { satispress } = makeResolvers({ runner });
+  assert.strictEqual(await satispress('nope'), null);
+});
+
+test('satispress returns null on unparseable composer output', async () => {
+  const runner = fakeRunner(() => ({ code: 0, stdout: 'not json', stderr: '' }));
+  const { satispress } = makeResolvers({ runner });
+  assert.strictEqual(await satispress('x'), null);
 });


### PR DESCRIPTION
## The real question this answers
Why did classify() have its own hand-rolled SatisPress auth (a raw `fetch()` + guessed Basic-auth header) instead of using the already-normalized `action-composer-auth`? Answer: it never did — it was a **separate, parallel implementation** that could (and did) drift from the real one.

## What happened
Live on ci-test-ftp, rung 3's own guard caught this: \`amazon-s3-and-cloudfront-pro\` reached adoption classified \`premium-flag\`, but the guard's \`composer show saucal/amazon-s3-and-cloudfront-pro --all\` (authenticated via \`auth.json\`) **found it**. So \`classify()\`'s own resolver was wrong — the package genuinely resolves on SatisPress.

First fix attempt (superseded, see history): patch the resolver's password to match composer's convention. That's a symptom fix — it leaves two independent SatisPress-auth implementations that can drift apart again.

## Actual fix
Route \`satispress()\` through **composer itself** (\`composer show <pkg> --all --format=json\`) — the exact same composer instance \`action-composer-auth\` already configured. There is now exactly **one** place SatisPress credentials are ever handled in this whole pipeline; the resolver can no longer silently 401 independent of whether the real auth works.

- \`resolvers.js\`: \`makeResolvers({ fetch, runner, cwd })\`; \`satispress()\` shells out via \`runner.composer(['show', ...])\`, parses \`.versions\`, skips dev/branch-alias entries.
- \`index.js\`: drops \`SATISPRESS_URL\`/\`SATISPRESS_TOKEN\` reads and the homepage-lookup entirely.
- \`action.yml\`: those two inputs kept (no interface break for existing callers) but marked deprecated/no-op; dead env wiring removed.

**75 unit / 16 integration green.**

Expected next live result: \`amazon-s3-and-cloudfront-pro\` should classify as a normal \`satispress\` **add** (not premium-flag/adoption at all) — the correct outcome, since it turns out to genuinely resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)