### PR TITLE
Verify convergence after reconcile — report where we land

### DIFF
--- a/reconcile/index.js
+++ b/reconcile/index.js
@@ -79,8 +79,20 @@ async function sh(cmd, args, opts = {}) {
     core.setFailed(`reconcile-run failed: ${e.stack || e}`);
     return;
   }
-  const { classified, outcome, applied } = result;
+  const { classified, outcome, applied, verification } = result;
   core.info(`Reconcile outcome: ${outcome} | applied: ${applied.join(', ') || '(none)'}`);
+
+  // Where we land: verified = a deploy from this PR reproduces the server for that component;
+  // residual = still differs after apply. Compared locally against the server state the check
+  // already captured — no second rsync.
+  if (verification && verification.verifiable) {
+    core.info(`Verified ${verification.verified}/${verification.verifiable} recovered components reproduce the server; ${verification.residual} with residual drift.`);
+    for (const c of classified) {
+      if (c.verified === false) {
+        core.warning(`${c.key}: applied, but ${c.residualFiles} file(s) still differ from the server after apply — the fix does not fully converge here.`);
+      }
+    }
+  }
 
   // Surface composer's actual complaint for anything flagged unavailable (why the version
   // couldn't be installed: missing version, stability, or a broken global solve).

--- a/reconcile/lib/reconcile-run.js
+++ b/reconcile/lib/reconcile-run.js
@@ -9,6 +9,7 @@ const { decideOutcome } = require('./outcome');
 const { reconcilePatched } = require('./reconcile-patched');
 const { adoptComponent } = require('./adopt');
 const { isSensitive } = require('./detectors');
+const { generatePatch } = require('./patch-gen');
 
 /**
  * Orchestrator core (no git/gh). Classifies drift and applies recoverable changes to the
@@ -186,9 +187,31 @@ async function reconcileRun(o) {
     }
   }
 
+  // Pass 4 — verify convergence (where do we land?). The consistency check already reverse-synced
+  // the LIVE server into treeRoot (built/), and every applied change is installed/vendored under
+  // sourceDir. Byte-compare each recovered component's reconciled tree against the captured server
+  // state: `verified` means a deploy from this PR reproduces the server for that component;
+  // residual files mean the fix is incomplete (the site would still drift there). This reuses the
+  // server state already captured — no second rsync/SSH or rebuild needed.
+  let verified = 0;
+  let verifiable = 0;
+  for (const c of classified) {
+    if (!c.recoverable || !c.root) continue;
+    const srcDir = path.join(o.sourceDir, c.root);
+    const srvDir = path.join(o.treeRoot, c.root);
+    if (!fs.existsSync(srcDir) || !fs.existsSync(srvDir)) continue; // can't compare locally → leave unknown
+    let residual;
+    try { residual = generatePatch(srcDir, srvDir, c.root); } catch { continue; }
+    verifiable++;
+    c.verified = residual.trim() === '';
+    if (c.verified) verified++;
+    else c.residualFiles = (residual.match(/^diff --git/gm) || []).length;
+  }
+  const verification = { verified, verifiable, residual: verifiable - verified };
+
   // Compute outcome last so the cweagans downgrade is reflected.
   const outcome = decideOutcome(classified);
-  return { classified, outcome, applied, adoptedPaths };
+  return { classified, outcome, applied, adoptedPaths, verification };
 }
 
 /** Pull the most informative line out of composer's error output for a one-line reason. */

--- a/reconcile/lib/report.js
+++ b/reconcile/lib/report.js
@@ -18,16 +18,27 @@ function reportBody(classified, meta) {
   const needsReview = classified.filter((c) =>
     !c.recoverable && c.category !== 'ignorable' && c.category !== 'compiled-asset' && c.category !== 'sensitive');
 
+  // Verification (where we land): recovered components byte-compared against the captured server
+  // state. verified = a deploy reproduces the server; residual = still differs after apply.
+  const verifiable = classified.filter((c) => c.verified !== undefined);
+  const okCount = verifiable.filter((c) => c.verified).length;
+  const verifyLine = meta.verify || (verifiable.length
+    ? `verified ${okCount}/${verifiable.length} recovered components reproduce the server`
+      + (okCount < verifiable.length ? ' — residual drift remains, see below' : ' byte-for-byte')
+    : '');
+  const tag = (c) => c.verified === true ? '  ✅ verified — reproduces the server'
+    : c.verified === false ? `  ⚠️ residual — ${c.residualFiles} file(s) still differ after apply` : '';
+
   const L = [];
   L.push(`## Consistency reconciliation — \`${meta.ref}\``);
   L.push('');
-  L.push(`**Outcome:** ${outcome}${meta.verify ? ` (${meta.verify})` : ''}`);
+  L.push(`**Outcome:** ${outcome}${verifyLine ? ` (${verifyLine})` : ''}`);
   L.push('');
-  L.push(`Generated from the [consistency check run](${meta.runUrl}). The server filesystem drifted from the deployed build; this PR captures the recoverable changes back into source.`);
+  L.push(`Generated from the [consistency check run](${meta.runUrl}). The server filesystem drifted from the deployed build; this PR captures the recoverable changes back into source. Recovered items are byte-compared against the live server state captured during the check — see the ✅/⚠️ tags.`);
   L.push('');
-  pushSection(L, '✅ Applied (in this PR)', applied, (c) => `\`${c.composerPackage || c.key}\` — ${c.remediation}`);
-  pushSection(L, '🩹 Patched (modified from published)', patched, (c) => `\`${c.composerPackage || c.key}\` — ${c.remediation}`);
-  pushSection(L, '📦 Adopted (vendored into repo)', adopted, (c) => `\`${c.key}\` — ${c.remediation}`);
+  pushSection(L, '✅ Applied (in this PR)', applied, (c) => `\`${c.composerPackage || c.key}\` — ${c.remediation}${tag(c)}`);
+  pushSection(L, '🩹 Patched (modified from published)', patched, (c) => `\`${c.composerPackage || c.key}\` — ${c.remediation}${tag(c)}`);
+  pushSection(L, '📦 Adopted (vendored into repo)', adopted, (c) => `\`${c.key}\` — ${c.remediation}${tag(c)}`);
   pushSection(L, '⚠️ Needs review', needsReview, (c) => `\`${c.key}\` — ${c.remediation}`);
   pushSection(L, '🧹 Ignorable (no source change)', ignorable, (c) => `\`${c.key}\` — ${c.remediation}`);
   pushSection(L, '⛔ Unrecoverable', unrecoverable, (c) => `\`${c.key}\` — ${c.remediation}`);

--- a/reconcile/test/integration/scenarios.integration.test.js
+++ b/reconcile/test/integration/scenarios.integration.test.js
@@ -125,6 +125,9 @@ test('bump: clean newer version on server -> bump-only, no patch', async () => {
     `patched-candidate resolved bump-only: ${res.applied}`
   );
   assert.ok(!fs.existsSync(path.join(dir, 'patches', 'verplug.patch')), 'no patch written');
+  // Verify pass (real composer): the bumped install byte-matches the server's 1.1.0 dir → converges.
+  const vp = findByKey(res.classified, 'verplug');
+  assert.strictEqual(vp.verified, true, 'bump verifies clean against server');
 });
 
 // --- 3. patch -----------------------------------------------------------
@@ -451,6 +454,8 @@ test('adopt: plugin on neither wpackagist nor SatisPress -> vendored into source
   assert.ok(fs.existsSync(path.join(dir, 'plugins/premiumx/premiumx.php')), 'vendored main file');
   assert.ok(fs.existsSync(path.join(dir, 'plugins/premiumx/inc/helper.php')), 'vendored nested file');
   assert.ok(res.adoptedPaths.includes('plugins/premiumx'), `adoptedPaths: ${res.adoptedPaths}`);
+  // Verify pass: the vendored copy reproduces the server exactly.
+  assert.strictEqual(c.verified, true, 'adopted plugin verifies clean against server');
 });
 
 // --- 10. bootstrap cweagans on a repo that lacks it ---------------------

--- a/reconcile/test/reconcile-run.test.js
+++ b/reconcile/test/reconcile-run.test.js
@@ -120,6 +120,29 @@ test('adopt: premium-flag component is vendored into source when the flag is on'
   assert.ok(fs.existsSync(path.join(sourceDir, 'plugins/premiumplug/premiumplug.php')), 'vendored into source');
   assert.deepStrictEqual(res.adoptedPaths, ['plugins/premiumplug']);
   assert.ok(res.applied.includes('adopt:premiumplug'), res.applied.join(','));
+  // Verify pass: the vendored source now byte-matches the captured server state → reproduces it.
+  assert.strictEqual(c.verified, true);
+  assert.deepStrictEqual(res.verification, { verified: 1, verifiable: 1, residual: 0 });
+});
+
+test('verify: adopted-lossy (a non-manifest sensitive file skipped) reports residual — does NOT fully converge', async () => {
+  const sourceDir = tmpSource();
+  const treeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'tree-'));
+  fs.mkdirSync(path.join(treeRoot, 'plugins', 'premiumplug', 'inc'), { recursive: true });
+  fs.writeFileSync(path.join(treeRoot, 'plugins', 'premiumplug', 'premiumplug.php'), '<?php // premium\n');
+  // Credentials file present in the server dir but NOT in the drift manifest: adopt's full-dir
+  // copy hits and skips it (sensitive), so the vendored plugin is missing it → residual.
+  fs.writeFileSync(path.join(treeRoot, 'plugins', 'premiumplug', 'inc', 'secret-credentials.php'), '<?php return ["k"=>"v"];\n');
+  const runner = { calls: [], composer(args) { return { code: args[0] === 'show' ? 1 : 0, stdout: '', stderr: '' }; } };
+
+  const res = await reconcileRun({ sourceDir, treeRoot, manifestText: premiumManifest, resolvers: noResolve, runner, adopt: true });
+
+  const c = res.classified.find((x) => x.key === 'premiumplug');
+  assert.strictEqual(c.category, 'adopted-lossy');
+  assert.strictEqual(c.verified, false);
+  assert.ok(c.residualFiles >= 1, `residualFiles: ${c.residualFiles}`);
+  assert.strictEqual(res.verification.residual, 1);
+  assert.ok(!fs.existsSync(path.join(sourceDir, 'plugins/premiumplug/inc/secret-credentials.php')), 'sensitive file not vendored');
 });
 
 test('adopt: off by default -> premium-flag stays flagged, nothing vendored', async () => {

--- a/reconcile/test/report.test.js
+++ b/reconcile/test/report.test.js
@@ -51,3 +51,20 @@ test('no verify status -> header has no suffix (backward compatible)', () => {
   const body = reportBody([{ key: 'x', category: 'ignorable', recoverable: false, remediation: 'junk' }], { ref: 'develop', runUrl: 'u' });
   assert.match(body, /\*\*Outcome:\*\* ignorable-only$/m);
 });
+
+test('per-item verify tags render and the outcome auto-summarizes convergence', () => {
+  const items = [
+    { key: 'ok', category: 'wpackagist-plugin', recoverable: true, composerPackage: 'wpackagist-plugin/ok', remediation: 'add', verified: true },
+    { key: 'part', category: 'adopted', recoverable: true, remediation: 'vendored', verified: false, residualFiles: 3 },
+  ];
+  const body = reportBody(items, { ref: 'main', runUrl: 'u' });
+  assert.match(body, /✅ verified — reproduces the server/);
+  assert.match(body, /⚠️ residual — 3 file\(s\) still differ after apply/);
+  assert.match(body, /verified 1\/2 recovered components reproduce the server — residual drift remains/);
+});
+
+test('all recovered items verified -> outcome says byte-for-byte', () => {
+  const items = [{ key: 'ok', category: 'wpackagist-plugin', recoverable: true, composerPackage: 'wpackagist-plugin/ok', remediation: 'add', verified: true }];
+  const body = reportBody(items, { ref: 'main', runUrl: 'u' });
+  assert.match(body, /verified 1\/1 recovered components reproduce the server byte-for-byte/);
+});


### PR DESCRIPTION
## The gap
Reconcile applied fixes but never told you **whether they converge**. The job's pass/fail verdict is fixed by the initial rsync — *before* reconcile touches anything — so every reconciling run reads as `failure` with zero signal on whether the composer adds/patches/adoption actually bring the site back in sync.

Answering "do we run another rsync / loop after reconciling?" — **no, and we don't need to.**

## The insight (no second SSH)
When the initial consistency check detects drift, `action-deploy-ssh`'s `getRsyncDiff()` does a **real reverse rsync — server → `built/`** — so by the time reconcile runs, `built/` (`treeRoot`) already holds the **full live server state**. Every applied fix is installed/vendored under `source/`. So convergence is a **local byte-compare** of the reconciled `source/<component>` against the captured `built/<component>` — reusing `patch-gen`'s `generatePatch` (empty diff = identical). No second rsync, no SSH round-trip, no rebuild.

## What you get
Per recovered component:
- **✅ verified** — a deploy from this PR reproduces the server there
- **⚠️ residual — N file(s) still differ** — the fix is incomplete; the site would still drift

Surfaced as per-item tags in the PR body, an outcome summary (`verified N/M recovered components reproduce the server byte-for-byte` / `… residual drift remains`), and a `core.warning` per residual component so an incomplete "applied" is loud, not silent.

## Tests
- +2 unit: clean adopt verifies; adopted-lossy (a non-manifest sensitive file skipped) correctly reports residual.
- +2 report: per-item tags + auto summary.
- +2 integration (real composer): version-bump converges clean; adoption reproduces the server exactly.

**78 unit / 16 integration green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)