### PR TITLE
Reconcile: install the server's exact version, don't bump constraints

### DIFF
--- a/reconcile/lib/composer.js
+++ b/reconcile/lib/composer.js
@@ -17,6 +17,19 @@ function upsertRequire(composer, pkg, constraint) {
 }
 
 /**
+ * True when a constraint names a single exact version with no range/wildcard operators — a
+ * deliberate pin the reconcile must not change (e.g. "1.2.3", "==1.2.3", "v1.2.3", "dev-main").
+ * Ranges ("`>=1.2`", "^1.2", "~1.2", "1.2.*", "1.0 - 2.0", "a || b") return false.
+ * @param {string} s
+ * @returns {boolean}
+ */
+function isPinnedConstraint(s) {
+  if (typeof s !== 'string') return false;
+  const t = s.trim().replace(/^==\s*/, '');
+  return t !== '' && !/[<>~^*|@\s]/.test(t);
+}
+
+/**
  * Remove a require entry (used to revert an add whose constraint composer couldn't satisfy).
  * Returns a new object (input untouched).
  * @param {object} composer
@@ -111,4 +124,4 @@ function serializeComposer(obj, originalText) {
   return out;
 }
 
-module.exports = { upsertRequire, removeRequire, ensureCweagansSetup, serializeComposer };
+module.exports = { upsertRequire, removeRequire, isPinnedConstraint, ensureCweagansSetup, serializeComposer };

--- a/reconcile/lib/reconcile-run.js
+++ b/reconcile/lib/reconcile-run.js
@@ -4,7 +4,7 @@ const path = require('path');
 const { parseManifest } = require('./parse-drift');
 const { parseContentDiff, modifiedPaths } = require('./parse-content-diff');
 const { classify, versionConstraint } = require('./classify');
-const { upsertRequire, removeRequire, ensureCweagansSetup, serializeComposer } = require('./composer');
+const { upsertRequire, removeRequire, isPinnedConstraint, ensureCweagansSetup, serializeComposer } = require('./composer');
 const { decideOutcome } = require('./outcome');
 const { reconcilePatched } = require('./reconcile-patched');
 const { adoptComponent } = require('./adopt');
@@ -84,47 +84,61 @@ async function reconcileRun(o) {
     if (upd.code !== 0) applied.push('bootstrap:cweagans:update-failed');
   }
 
-  // Pass 1 — require add/bump (also pins patched-candidate to its target version), applied ONE
-  // package at a time so composer's resolver acts as the availability check. The version is
-  // derived from the server's plugin header; if no published package satisfies `>=<version>`
-  // (e.g. the server runs a dev/unreleased build), composer update fails — we then REVERT the
-  // constraint (never commit an uninstallable composer.json) and flag it as a decision rather
-  // than reporting a false "Applied". Without this, merging the PR would not bring the site
-  // back in sync. ponytail: sequential updates (n small); batch if a repo ever adds dozens.
+  // Pass 1 — reproduce the server's EXACT version without bumping constraints. Install the
+  // server's version into the LOCK via a temporary constraint (`--with <pkg>:<ver>`), leaving
+  // composer.json's range untouched (add only a `>=<server>` floor for a brand-new require). This
+  // makes the build byte-reproduce the server (convergence) instead of jumping to the latest that
+  // satisfies `>=` — the whole point of reconciling. A deliberately-pinned exact constraint is
+  // never changed; it's flagged instead. Applied ONE package at a time so composer's resolver acts
+  // as the availability check; an unsatisfiable target reverts + flags rather than faking success.
+  // ponytail: sequential updates (n small).
   for (const c of classified) {
     if (!c.recoverable || !c.composerPackage || !composer) continue;
-    const constraint = versionConstraint(c.version);
+    const target = c.version; // exact version to lock (server's, or a composer-valid fallback)
     const had = !!(composer.require && Object.prototype.hasOwnProperty.call(composer.require, c.composerPackage));
-    const prev = had ? composer.require[c.composerPackage] : undefined;
+    const existing = had ? composer.require[c.composerPackage] : undefined;
 
-    const r = upsertRequire(composer, c.composerPackage, constraint);
-    composer = r.composer;
-    fs.writeFileSync(composerPath, serializeComposer(composer, originalComposerText));
+    // Respect a deliberate pin: never change it. If it already equals the server version there's
+    // nothing to do (it verifies clean); otherwise flag — reconciling would mean changing the pin.
+    if (had && isPinnedConstraint(existing)) {
+      const pinned = existing.trim().replace(/^==\s*/, '');
+      if (!target || pinned === String(target)) { applied.push(`require:${c.composerPackage}:pinned-ok`); continue; }
+      c.recoverable = false;
+      c.category = 'pinned-constraint';
+      c.remediation = `${c.composerPackage} is pinned to \`${existing}\` in composer.json, but the server has v${target}. The pin is intentional — reconcile won't change it. Update the pin manually to adopt the server's version.`;
+      applied.push(`require:${c.composerPackage}:pinned`);
+      continue;
+    }
 
-    if (!o.runner) { if (r.changed) composerChanged = true; continue; }
+    // New require: add a `>=<server>` floor. Existing range: leave it unchanged (do NOT bump).
+    if (!had) {
+      composer = upsertRequire(composer, c.composerPackage, versionConstraint(target)).composer;
+      fs.writeFileSync(composerPath, serializeComposer(composer, originalComposerText));
+    }
 
-    // Partial update first: keep every other package at its locked version so a pre-existing
-    // unsatisfiable sibling (e.g. a delisted plugin already in the repo) can't fail THIS plugin's
-    // solve. Escalate to -W only if the plugin genuinely needs its own dependencies co-updated.
-    let upd = await o.runner.composer(['update', c.composerPackage, '--no-progress'], { cwd: o.sourceDir });
+    if (!o.runner) { if (!had) composerChanged = true; continue; }
+
+    // Install the exact server version into the lock, keeping composer.json's constraint. Partial
+    // update first (keep siblings locked so a broken sibling can't fail this solve); escalate to -W
+    // only if the plugin genuinely needs its own deps co-updated.
+    const withArg = target ? ['--with', `${c.composerPackage}:${target}`] : [];
+    let upd = await o.runner.composer(['update', c.composerPackage, ...withArg, '--no-progress'], { cwd: o.sourceDir });
     if (upd.code !== 0) {
-      upd = await o.runner.composer(['update', c.composerPackage, '-W', '--no-progress'], { cwd: o.sourceDir });
+      upd = await o.runner.composer(['update', c.composerPackage, '-W', ...withArg, '--no-progress'], { cwd: o.sourceDir });
     }
     if (upd.code !== 0) {
-      // Unsatisfiable — restore the prior constraint (or drop the add) so composer.json stays installable.
-      composer = (had ? upsertRequire(composer, c.composerPackage, prev) : removeRequire(composer, c.composerPackage)).composer;
-      fs.writeFileSync(composerPath, serializeComposer(composer, originalComposerText));
+      // Unsatisfiable — drop a new-add require so composer.json stays installable (existing range
+      // constraints were never touched, so there's nothing to revert for a bump).
+      if (!had) { composer = removeRequire(composer, c.composerPackage).composer; fs.writeFileSync(composerPath, serializeComposer(composer, originalComposerText)); }
       c.recoverable = false;
       c.category = 'version-unavailable';
-      // Surface composer's own reason so the log/PR say WHY (missing version vs. stability vs. a
-      // broken global solve), instead of an opaque "unavailable".
       c.composerOutput = ((upd.stdout || '') + (upd.stderr || '')).trim().slice(-1600);
       const reason = firstComposerError(c.composerOutput);
-      c.remediation = `Server has ${c.key}${c.version ? ` v${c.version}` : ''}, but composer could not install \`${c.composerPackage}:${constraint}\`${reason ? ` — ${reason}` : ''}. Merging would not bring the site in sync; resolve and re-run.`;
+      c.remediation = `Server has ${c.key}${target ? ` v${target}` : ''}, but composer could not install \`${c.composerPackage}\`${target ? ` at v${target}` : ''}${reason ? ` — ${reason}` : ''}. Merging would not bring the site in sync; resolve and re-run.`;
       applied.push(`require:${c.composerPackage}:unavailable`);
       continue;
     }
-    if (r.changed) composerChanged = true;
+    if (!had) composerChanged = true;
     applied.push(`require:${c.composerPackage}`);
   }
 

--- a/reconcile/test/composer.test.js
+++ b/reconcile/test/composer.test.js
@@ -1,7 +1,16 @@
 'use strict';
 const test = require('node:test');
 const assert = require('node:assert');
-const { upsertRequire, ensureCweagansSetup, serializeComposer } = require('../lib/composer');
+const { upsertRequire, ensureCweagansSetup, serializeComposer, isPinnedConstraint } = require('../lib/composer');
+
+test('isPinnedConstraint: exact versions are pins, ranges are not', () => {
+  for (const s of ['1.2.3', '1.2', '==1.2.3', 'v1.2.3', '1.2.3-beta2', 'dev-main']) {
+    assert.strictEqual(isPinnedConstraint(s), true, `pin: ${s}`);
+  }
+  for (const s of ['>=1.2', '^1.2', '~1.2.3', '1.2.*', '>1.0 <2.0', '1.0 || 2.0', '*', '@dev', '', null]) {
+    assert.strictEqual(isPinnedConstraint(s), false, `range: ${s}`);
+  }
+});
 
 test('adds a new package and reports changed', () => {
   const base = { require: { 'php': '>=8.1' } };

--- a/reconcile/test/helpers/make-project.js
+++ b/reconcile/test/helpers/make-project.js
@@ -37,6 +37,7 @@ function makeProject(o) {
     'cweagans/composer-patches': '^2.0',
   };
   const seenPkg = new Set();
+  const baseline = {}; // pkg -> first-occurrence version, locked exactly in the built state
 
   function addPathRepo(p, isTheme) {
     const pkgDir = path.join(pkgsRoot, `${p.slug}-${p.version}`);
@@ -83,9 +84,12 @@ function makeProject(o) {
       canonical: false,
     });
 
-    // First occurrence of a pkg pins the root require constraint.
+    // First occurrence of a pkg sets the root require constraint. Default to a `>=` RANGE (as real
+    // Saucal projects do) with the exact version locked separately below; `pin: true` uses an exact
+    // constraint instead (to exercise the "don't touch a deliberate pin" path).
     if (!seenPkg.has(p.pkg)) {
-      require[p.pkg] = p.version;
+      require[p.pkg] = p.pin ? p.version : `>=${p.version}`;
+      baseline[p.pkg] = p.version;
       seenPkg.add(p.pkg);
     }
   }
@@ -146,7 +150,12 @@ function makeProject(o) {
     JSON.stringify(composer, null, 4) + '\n'
   );
 
-  execFileSync('composer', ['install', '--no-interaction', '--no-progress'], {
+  // Lock each package at its baseline (first-occurrence) version while keeping the (possibly
+  // ranged) constraint — mirrors real projects: `>=X` in composer.json, exact X in composer.lock,
+  // newer versions available in the repos. Uses `composer update --with` (the same mechanism the
+  // reconcile uses) so a `>=` constraint doesn't silently grab the latest at build time.
+  const withArgs = Object.entries(baseline).flatMap(([pkg, v]) => ['--with', `${pkg}:${v}`]);
+  execFileSync('composer', ['update', '--no-interaction', '--no-progress', ...withArgs], {
     cwd: dir,
     stdio: 'pipe',
     maxBuffer: 64 * 1024 * 1024,

--- a/reconcile/test/integration/scenarios.integration.test.js
+++ b/reconcile/test/integration/scenarios.integration.test.js
@@ -19,6 +19,7 @@ const KNOWN = {
   verplug: { source: 'satispress', package: 'saucal/verplug', version: '1.1.0' },
   patchplug: { source: 'satispress', package: 'saucal/patchplug', version: '1.0.0' },
   thmx: { source: 'satispress', package: 'saucal/thmx', version: '1.0.0' },
+  pinplug: { source: 'satispress', package: 'saucal/pinplug', version: '1.1.0' },
 };
 
 const fakeResolvers = {
@@ -119,15 +120,49 @@ test('bump: clean newer version on server -> bump-only, no patch', async () => {
     runner: makeRunner(),
   });
 
-  assert.match(read(installed), /Version: 1\.1\.0/, 'installed bumped to 1.1.0');
+  assert.match(read(installed), /Version: 1\.1\.0/, 'installed bumped to 1.1.0 (the server version, not >=latest)');
   assert.ok(
     res.applied.includes('patched:verplug:bump-only'),
     `patched-candidate resolved bump-only: ${res.applied}`
   );
   assert.ok(!fs.existsSync(path.join(dir, 'patches', 'verplug.patch')), 'no patch written');
+  // The `>=1.0.0` range constraint is NOT bumped — only the lock moves to the server's version.
+  const cj = JSON.parse(read(path.join(dir, 'composer.json')));
+  assert.strictEqual(cj.require['saucal/verplug'], '>=1.0.0', 'composer.json constraint left unchanged');
   // Verify pass (real composer): the bumped install byte-matches the server's 1.1.0 dir → converges.
   const vp = findByKey(res.classified, 'verplug');
   assert.strictEqual(vp.verified, true, 'bump verifies clean against server');
+});
+
+// --- 2b. pinned constraint (do not touch) -------------------------------
+test('bump: a deliberately-pinned constraint is left untouched and flagged (not bumped)', async () => {
+  const { dir } = makeProject({
+    plugins: [
+      { slug: 'pinplug', pkg: 'saucal/pinplug', version: '1.0.0', body: '// v code\n', pin: true },
+      { slug: 'pinplug', pkg: 'saucal/pinplug', version: '1.1.0', body: '// v code\n' },
+    ],
+  });
+  const composerBefore = read(path.join(dir, 'composer.json'));
+  assert.strictEqual(JSON.parse(composerBefore).require['saucal/pinplug'], '1.0.0', 'starts pinned exact');
+  const installed = path.join(dir, 'plugins/pinplug/pinplug.php');
+  assert.match(read(installed), /Version: 1\.0\.0/);
+
+  const src111 = path.join(dir, 'pkgs/pinplug-1.1.0');
+  const serverDir = stageServer(dir, (sv) => {
+    const dst = path.join(sv, 'plugins/pinplug');
+    fs.rmSync(dst, { recursive: true, force: true });
+    fs.mkdirSync(dst, { recursive: true });
+    for (const f of fs.readdirSync(src111)) fs.copyFileSync(path.join(src111, f), path.join(dst, f));
+  });
+
+  const { manifestText, contentDiffText } = deriveDrift(dir, serverDir);
+  const res = await reconcileRun({ sourceDir: dir, treeRoot: serverDir, manifestText, contentDiffText, resolvers: fakeResolvers, runner: makeRunner() });
+
+  const c = findByKey(res.classified, 'pinplug');
+  assert.strictEqual(c.category, 'pinned-constraint');
+  assert.strictEqual(c.recoverable, false);
+  assert.strictEqual(read(path.join(dir, 'composer.json')), composerBefore, 'pinned composer.json untouched');
+  assert.match(read(installed), /Version: 1\.0\.0/, 'still the pinned version — not bumped to the server 1.1.0');
 });
 
 // --- 3. patch -----------------------------------------------------------

--- a/reconcile/test/reconcile-run.test.js
+++ b/reconcile/test/reconcile-run.test.js
@@ -6,9 +6,9 @@ const os = require('os');
 const path = require('path');
 const { reconcileRun } = require('../lib/reconcile-run');
 
-function tmpSource() {
+function tmpSource(require = {}) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'src-'));
-  fs.writeFileSync(path.join(dir, 'composer.json'), JSON.stringify({ name: 't/t', require: {} }, null, 4) + '\n');
+  fs.writeFileSync(path.join(dir, 'composer.json'), JSON.stringify({ name: 't/t', require }, null, 4) + '\n');
   return dir;
 }
 
@@ -50,6 +50,9 @@ test('add/bump: recoverable wpackagist add writes require, runs composer update,
   assert.ok(upd, 'an update call was made');
   assert.ok(upd.args.includes('wpackagist-plugin/code-snippets'));
   assert.ok(!upd.args.includes('-W'), 'first update is partial (no -W)');
+  // Install pins the EXACT server version into the lock (not >=latest) via --with.
+  assert.ok(upd.args.includes('--with'), 'uses --with to lock the exact version');
+  assert.ok(upd.args.includes('wpackagist-plugin/code-snippets:3.6.5'), '--with names the server version');
   assert.strictEqual(upd.opts.cwd, sourceDir);
 
   assert.deepStrictEqual(res.applied, ['require:wpackagist-plugin/code-snippets']);
@@ -78,6 +81,43 @@ test('unavailable: composer update fails -> constraint reverted, flagged version
   assert.strictEqual(fs.readFileSync(path.join(sourceDir, 'composer.json'), 'utf8'), before);
   assert.ok(res.applied.includes('require:wpackagist-plugin/code-snippets:unavailable'), res.applied.join(','));
   assert.strictEqual(res.outcome, 'unrecoverable-only');
+});
+
+test('existing RANGE constraint is NOT bumped; exact server version installed via --with', async () => {
+  const sourceDir = tmpSource({ 'wpackagist-plugin/code-snippets': '>=1.0.0' });
+  const runner = fakeRunner();
+  const res = await reconcileRun({ sourceDir, treeRoot: '/nonexistent', manifestText: 'deleting plugins/code-snippets/code-snippets.php\n', resolvers, runner });
+
+  // composer.json constraint left exactly as-is (not raised to >=3.6.5).
+  const composer = JSON.parse(fs.readFileSync(path.join(sourceDir, 'composer.json'), 'utf8'));
+  assert.strictEqual(composer.require['wpackagist-plugin/code-snippets'], '>=1.0.0');
+  // but the lock is pinned to the server version via --with.
+  const upd = runner.calls.find((k) => k.args[0] === 'update' && k.args.includes('wpackagist-plugin/code-snippets'));
+  assert.ok(upd.args.includes('wpackagist-plugin/code-snippets:3.6.5'), '--with pins server version');
+  assert.ok(res.applied.includes('require:wpackagist-plugin/code-snippets'));
+});
+
+test('a PINNED constraint that differs from the server is never changed -> flagged pinned-constraint', async () => {
+  const sourceDir = tmpSource({ 'wpackagist-plugin/code-snippets': '3.0.0' });
+  const before = fs.readFileSync(path.join(sourceDir, 'composer.json'), 'utf8');
+  const runner = fakeRunner();
+  const res = await reconcileRun({ sourceDir, treeRoot: '/nonexistent', manifestText: 'deleting plugins/code-snippets/code-snippets.php\n', resolvers, runner });
+
+  const c = res.classified.find((x) => x.key === 'code-snippets');
+  assert.strictEqual(c.category, 'pinned-constraint');
+  assert.strictEqual(c.recoverable, false);
+  assert.strictEqual(fs.readFileSync(path.join(sourceDir, 'composer.json'), 'utf8'), before, 'composer.json untouched');
+  assert.ok(!runner.calls.some((k) => k.args[0] === 'update' && k.args.includes('wpackagist-plugin/code-snippets')), 'no install attempted');
+  assert.ok(res.applied.includes('require:wpackagist-plugin/code-snippets:pinned'));
+});
+
+test('a PINNED constraint already equal to the server version is a clean no-op (pinned-ok)', async () => {
+  const sourceDir = tmpSource({ 'wpackagist-plugin/code-snippets': '3.6.5' });
+  const runner = fakeRunner();
+  const res = await reconcileRun({ sourceDir, treeRoot: '/nonexistent', manifestText: 'deleting plugins/code-snippets/code-snippets.php\n', resolvers, runner });
+
+  assert.ok(res.applied.includes('require:wpackagist-plugin/code-snippets:pinned-ok'));
+  assert.ok(!runner.calls.some((k) => k.args[0] === 'update' && k.args.includes('wpackagist-plugin/code-snippets')), 'no install attempted');
 });
 
 test('flag-only: sensitive item leaves composer untouched, no runner call, empty applied', async () => {


### PR DESCRIPTION
## Why
The verify pass (PR #16) proved live that pinning `>=<server-version>` **never converges** — composer installs the *latest* satisfying the range, not what the server runs:

| Plugin | Server | `>=` installed | 
|--------|--------|----------------|
| w3-total-cache | 1.2 | **2.10.1** (major jump) |
| woocommerce | 10.7.0 | 10.9.4 |
| amazon-s3 | 3.3.0 | 3.3.1 |

So the reconcile would deploy something quite different from the server, and the consistency check would *still* fail after deploy. Reconcile's job is to reproduce the server, not track latest.

## Strategy (per your guidance)
Decouple the **constraint** (loose, unchanged) from the **installed version** (exact = server's):
- Install the server's exact version into `composer.lock` via a temporary constraint — `composer update <pkg> --with <pkg>:<ver>` — leaving `composer.json`'s `>=X` **untouched** (no bump). The build reproduces the server; the constraint stays flexible.
- **New** require: add a `>=<server>` floor (as before). **Existing range**: not bumped.
- A **deliberately-pinned** exact constraint (`1.2.3`, `==1.2.3`, …) is **never changed** — flagged `pinned-constraint` (needs review) instead, since reconciling it would mean editing the pin.
- Unsatisfiable target still reverts a new-add and flags `version-unavailable`.

Verified the `--with` mechanism against real composer: it downgrades the lock to the named version while `composer.json` keeps `>=X`.

## Tests
- +3 reconcile-run unit (range not bumped; pin flagged; pin==server no-op), +1 `isPinnedConstraint` unit, +1 integration (pinned untouched).
- Harness `make-project` switched from exact-pin fixtures to realistic `>=` constraints with `--with`-locked baselines, so every scenario now exercises the range path; bump scenario asserts the constraint is unchanged and the lock holds the server's exact version.

**82 unit / 17 integration green.**

Expected live: w3tc locks **1.2** (not 2.10.1), woo **10.7.0**, amazon-s3 **3.3.0** → the verify pass should flip most of these to ✅. payoneer (`4.0.0-dev2`, unpublished) stays honest residual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)