### PR TITLE
reconcile: count the WS (whitespace-only) status as a content modification

### DIFF
--- a/reconcile/lib/parse-content-diff.js
+++ b/reconcile/lib/parse-content-diff.js
@@ -17,11 +17,14 @@ function parseContentDiff(text) {
 }
 
 /**
+ * 'WS' is consistency-diff.sh's collapsed form for a file that differs only in
+ * whitespace (a CRLF flip, a reindent). The body is omitted because it is noise, but
+ * the file is still modified relative to its published version, so it counts as M.
  * @param {{path:string, status:string}[]} items
- * @returns {Set<string>} paths whose status is 'M' (content-modified)
+ * @returns {Set<string>} paths that are content-modified
  */
 function modifiedPaths(items) {
-  return new Set(items.filter((i) => i.status === 'M').map((i) => i.path));
+  return new Set(items.filter((i) => i.status === 'M' || i.status === 'WS').map((i) => i.path));
 }
 
 module.exports = { parseContentDiff, modifiedPaths };

--- a/reconcile/test/parse-content-diff.test.js
+++ b/reconcile/test/parse-content-diff.test.js
@@ -6,6 +6,7 @@ const { parseContentDiff, modifiedPaths } = require('../lib/parse-content-diff')
 const SAMPLE = [
   'diff --git --simple D wp-content/cron-debug.log.tick',
   'diff --git --simple A plugins/newplug/new.php',
+  'diff --git --simple WS plugins/crlf-plug/main.php',
   'diff --git a/plugins/tooltips-pro/tooltips.php b/plugins/tooltips-pro/tooltips.php',
   'index b2567a0..1166545 100644',
   '--- a/plugins/tooltips-pro/tooltips.php',
@@ -20,6 +21,7 @@ test('classifies simple A/D entries and standard modified headers', () => {
   assert.deepStrictEqual(items, [
     { path: 'wp-content/cron-debug.log.tick', status: 'D' },
     { path: 'plugins/newplug/new.php', status: 'A' },
+    { path: 'plugins/crlf-plug/main.php', status: 'WS' },
     { path: 'plugins/tooltips-pro/tooltips.php', status: 'M' },
   ]);
 });
@@ -29,10 +31,10 @@ test('modified header without a/ b/ prefixes is still parsed as M', () => {
   assert.deepStrictEqual(items, [{ path: 'plugins/x/main.php', status: 'M' }]);
 });
 
-test('modifiedPaths returns only the M-status paths as a Set', () => {
+test('modifiedPaths returns the M- and WS-status paths as a Set', () => {
   const set = modifiedPaths(parseContentDiff(SAMPLE));
   assert.ok(set instanceof Set);
-  assert.deepStrictEqual([...set], ['plugins/tooltips-pro/tooltips.php']);
+  assert.deepStrictEqual([...set], ['plugins/crlf-plug/main.php', 'plugins/tooltips-pro/tooltips.php']);
 });
 
 test('empty / noise input yields no items', () => {


### PR DESCRIPTION
## Why

Companion to saucal/action-deploy-ssh#20, which collapses a file whose only difference is whitespace — a CRLF flip from an FTP edit, a reindent — to a single line instead of emitting every line of the file as changed:

```
diff --git --simple WS wp-content/plugins/foo/foo.php
```

Without this PR, that file drops out of `modifiedPaths`, and a drifted plugin gets classified `wpackagist`/`satispress` ("just add the package") instead of `patched-candidate`. The drift is real — the server's copy differs from the published version — so the remediation would silently lose it.

## What

`modifiedPaths` accepts `WS` alongside `M`. `WS` **is** a content modification; only its diff body is omitted, because that body is noise.

`parseContentDiff` itself needed no change — its `--simple` regex already captures any status token.

## Testing

`WS` fixture added to `test/parse-content-diff.test.js`. Full suite green: 82/82 (`npm test`).

## Merge order

Safe to merge before or after the deploy-ssh PR — until that one ships, no diff contains a `WS` line, so this is inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJiAywUjzsbkRbZNESL2y5