### PR TITLE
parse-content-diff: fix the b/ prefix strip, parse LL-tagged headers

### DIFF
--- a/reconcile/lib/parse-content-diff.js
+++ b/reconcile/lib/parse-content-diff.js
@@ -1,5 +1,11 @@
 'use strict';
 
+// consistency-diff.sh runs `git diff -R`, so its headers read `diff --git b/<path>
+// a/<path>` — the b/ side first. Strip either prefix: matching only a/ left every
+// content-modified path as `b/wp-content/...`, which equals no component path, so
+// isModified was permanently false and patched-candidate never fired.
+const stripPrefix = (p) => p.replace(/^[ab]\//, '');
+
 /**
  * Parse the consistency-check reverse content-diff buffer into per-file entries.
  * @param {string} text
@@ -8,21 +14,25 @@
 function parseContentDiff(text) {
   const items = [];
   for (const line of String(text).split('\n')) {
+    // `diff --git --simple LL b/x a/x` is a real diff whose long lines were truncated
+    // for readability. The tag warns a human the body is not applicable as a patch; the
+    // file is modified like any other, so it parses as M. Two paths follow the tag,
+    // which is what separates it from the bodiless one-liners below.
+    const tagged = line.match(/^diff --git --simple \S+ (\S+) (\S+)$/);
+    if (tagged) { items.push({ path: stripPrefix(tagged[1]), status: 'M' }); continue; }
     const simple = line.match(/^diff --git --simple (\S+) (.+)$/);
     if (simple) { items.push({ path: simple[2].trim(), status: simple[1] }); continue; }
     const std = line.match(/^diff --git (\S+) (\S+)$/);
-    if (std) { items.push({ path: std[1].replace(/^a\//, ''), status: 'M' }); continue; }
+    if (std) { items.push({ path: stripPrefix(std[1]), status: 'M' }); continue; }
   }
   return items;
 }
 
-// consistency-diff.sh collapses two kinds of modified file to a bodiless one-liner
-// because printing the body says nothing: 'WS' differs only in whitespace (a CRLF flip
-// from an FTP edit, a reindent), 'LL' has every changed line over the print limit (a
-// minified bundle rebuilt on one side). Both are content modifications exactly like 'M'
-// — the file on the server differs from its published version — so they belong here.
-// A/D/R are absent/renamed, not modified, and stay out.
-const MODIFIED_STATUSES = new Set(['M', 'WS', 'LL']);
+// 'WS' is consistency-diff.sh's bodiless form for a file that differs only in whitespace
+// (a CRLF flip from an FTP edit, a reindent). Printing the body would say nothing, but
+// the file on the server does differ from its published version, so it is a content
+// modification exactly like 'M'. A/D/R are absent/renamed, not modified, and stay out.
+const MODIFIED_STATUSES = new Set(['M', 'WS']);
 
 /**
  * @param {{path:string, status:string}[]} items

--- a/reconcile/lib/parse-content-diff.js
+++ b/reconcile/lib/parse-content-diff.js
@@ -16,15 +16,20 @@ function parseContentDiff(text) {
   return items;
 }
 
+// consistency-diff.sh collapses two kinds of modified file to a bodiless one-liner
+// because printing the body says nothing: 'WS' differs only in whitespace (a CRLF flip
+// from an FTP edit, a reindent), 'LL' has every changed line over the print limit (a
+// minified bundle rebuilt on one side). Both are content modifications exactly like 'M'
+// — the file on the server differs from its published version — so they belong here.
+// A/D/R are absent/renamed, not modified, and stay out.
+const MODIFIED_STATUSES = new Set(['M', 'WS', 'LL']);
+
 /**
- * 'WS' is consistency-diff.sh's collapsed form for a file that differs only in
- * whitespace (a CRLF flip, a reindent). The body is omitted because it is noise, but
- * the file is still modified relative to its published version, so it counts as M.
  * @param {{path:string, status:string}[]} items
  * @returns {Set<string>} paths that are content-modified
  */
 function modifiedPaths(items) {
-  return new Set(items.filter((i) => i.status === 'M' || i.status === 'WS').map((i) => i.path));
+  return new Set(items.filter((i) => MODIFIED_STATUSES.has(i.status)).map((i) => i.path));
 }
 
 module.exports = { parseContentDiff, modifiedPaths };

--- a/reconcile/test/parse-content-diff.test.js
+++ b/reconcile/test/parse-content-diff.test.js
@@ -7,11 +7,10 @@ const SAMPLE = [
   'diff --git --simple D wp-content/cron-debug.log.tick',
   'diff --git --simple A plugins/newplug/new.php',
   'diff --git --simple WS plugins/crlf-plug/main.php',
-  'diff --git --simple LL plugins/bundled-ui/dist/app.min.js',
-  'diff --git a/plugins/tooltips-pro/tooltips.php b/plugins/tooltips-pro/tooltips.php',
+  'diff --git b/plugins/tooltips-pro/tooltips.php a/plugins/tooltips-pro/tooltips.php',
   'index b2567a0..1166545 100644',
-  '--- a/plugins/tooltips-pro/tooltips.php',
-  '+++ b/plugins/tooltips-pro/tooltips.php',
+  '--- b/plugins/tooltips-pro/tooltips.php',
+  '+++ a/plugins/tooltips-pro/tooltips.php',
   '@@ -701,7 +701,7 @@',
   '-    $wp_rewrite->flush_rules();',
   '+    // disabled',
@@ -23,7 +22,6 @@ test('classifies simple A/D entries and standard modified headers', () => {
     { path: 'wp-content/cron-debug.log.tick', status: 'D' },
     { path: 'plugins/newplug/new.php', status: 'A' },
     { path: 'plugins/crlf-plug/main.php', status: 'WS' },
-    { path: 'plugins/bundled-ui/dist/app.min.js', status: 'LL' },
     { path: 'plugins/tooltips-pro/tooltips.php', status: 'M' },
   ]);
 });
@@ -33,12 +31,11 @@ test('modified header without a/ b/ prefixes is still parsed as M', () => {
   assert.deepStrictEqual(items, [{ path: 'plugins/x/main.php', status: 'M' }]);
 });
 
-test('modifiedPaths returns the M-, WS- and LL-status paths as a Set', () => {
+test('modifiedPaths returns the M- and WS-status paths as a Set', () => {
   const set = modifiedPaths(parseContentDiff(SAMPLE));
   assert.ok(set instanceof Set);
   assert.deepStrictEqual([...set], [
     'plugins/crlf-plug/main.php',
-    'plugins/bundled-ui/dist/app.min.js',
     'plugins/tooltips-pro/tooltips.php',
   ]);
 });
@@ -53,4 +50,27 @@ test('absent and renamed statuses are not content modifications', () => {
 test('empty / noise input yields no items', () => {
   assert.deepStrictEqual(parseContentDiff(''), []);
   assert.deepStrictEqual(parseContentDiff('some unrelated line\n@@ stray hunk\n'), []);
+});
+
+test('reverse-diff headers strip the b/ prefix, not just a/', () => {
+  // consistency-diff.sh runs `git diff -R`, so the b/ side comes first. Leaving the
+  // prefix on made every content-modified path unmatchable against a component path.
+  const items = parseContentDiff('diff --git b/wp-content/plugins/foo/bar.php a/wp-content/plugins/foo/bar.php\n');
+  assert.deepStrictEqual(items, [{ path: 'wp-content/plugins/foo/bar.php', status: 'M' }]);
+});
+
+test('an LL-tagged header is a modified file whose body was truncated', () => {
+  const items = parseContentDiff([
+    'diff --git --simple LL b/plugins/ui/dist/app.min.js a/plugins/ui/dist/app.min.js',
+    '@@ -2 +2 @@',
+    '-var a=2;xxx... [target line, 39.1 KB, truncated]',
+    '+var a=1;xxx... [build line, 39.1 KB, truncated]',
+  ].join('\n'));
+  assert.deepStrictEqual(items, [{ path: 'plugins/ui/dist/app.min.js', status: 'M' }]);
+  assert.deepStrictEqual([...modifiedPaths(items)], ['plugins/ui/dist/app.min.js']);
+});
+
+test('a tagged header is not confused with a bodiless one-liner', () => {
+  const items = parseContentDiff('diff --git --simple WS plugins/x/main.php\n');
+  assert.deepStrictEqual(items, [{ path: 'plugins/x/main.php', status: 'WS' }]);
 });

--- a/reconcile/test/parse-content-diff.test.js
+++ b/reconcile/test/parse-content-diff.test.js
@@ -7,6 +7,7 @@ const SAMPLE = [
   'diff --git --simple D wp-content/cron-debug.log.tick',
   'diff --git --simple A plugins/newplug/new.php',
   'diff --git --simple WS plugins/crlf-plug/main.php',
+  'diff --git --simple LL plugins/bundled-ui/dist/app.min.js',
   'diff --git a/plugins/tooltips-pro/tooltips.php b/plugins/tooltips-pro/tooltips.php',
   'index b2567a0..1166545 100644',
   '--- a/plugins/tooltips-pro/tooltips.php',
@@ -22,6 +23,7 @@ test('classifies simple A/D entries and standard modified headers', () => {
     { path: 'wp-content/cron-debug.log.tick', status: 'D' },
     { path: 'plugins/newplug/new.php', status: 'A' },
     { path: 'plugins/crlf-plug/main.php', status: 'WS' },
+    { path: 'plugins/bundled-ui/dist/app.min.js', status: 'LL' },
     { path: 'plugins/tooltips-pro/tooltips.php', status: 'M' },
   ]);
 });
@@ -31,10 +33,21 @@ test('modified header without a/ b/ prefixes is still parsed as M', () => {
   assert.deepStrictEqual(items, [{ path: 'plugins/x/main.php', status: 'M' }]);
 });
 
-test('modifiedPaths returns the M- and WS-status paths as a Set', () => {
+test('modifiedPaths returns the M-, WS- and LL-status paths as a Set', () => {
   const set = modifiedPaths(parseContentDiff(SAMPLE));
   assert.ok(set instanceof Set);
-  assert.deepStrictEqual([...set], ['plugins/crlf-plug/main.php', 'plugins/tooltips-pro/tooltips.php']);
+  assert.deepStrictEqual([...set], [
+    'plugins/crlf-plug/main.php',
+    'plugins/bundled-ui/dist/app.min.js',
+    'plugins/tooltips-pro/tooltips.php',
+  ]);
+});
+
+test('absent and renamed statuses are not content modifications', () => {
+  const set = modifiedPaths(parseContentDiff(
+    'diff --git --simple A a.php\ndiff --git --simple D b.php\ndiff --git --simple R c.php\n'
+  ));
+  assert.deepStrictEqual([...set], []);
 });
 
 test('empty / noise input yields no items', () => {


### PR DESCRIPTION
## The bug (pre-existing, live on v4)

`consistency-diff.sh` runs `git diff -R`, so its file headers read **`b/` first**:

```
diff --git b/wp-content/plugins/foo/bar.php a/wp-content/plugins/foo/bar.php
```

`parseContentDiff` stripped only `^a/`:

```js
if (std) { items.push({ path: std[1].replace(/^a\//, ''), status: 'M' }); continue; }
```

So every content-modified file came back as `b/wp-content/plugins/foo/bar.php`. That equals no `it.path` in any component, so `isModified` in `classify.js` was **permanently false** — `patched-candidate` never fired for a file carrying a standard diff header. Every drifted plugin was classified `wpackagist`/`satispress` instead, remediating to "add the package at version X" and silently dropping the fact that the server's copy was modified.

`WS` files worked by accident: the bodiless form has no prefix to strip.

Verified by running the merged `v4` parser against real script output:

```
parsed: [ ..., {"path":"b/wp-content/plugins/foo/bar.php","status":"M"} ]
modifiedPaths: [ 'crlf.php', 'b/wp-content/plugins/foo/bar.php' ]
```

The fixture hid it — `SAMPLE` used `a/`-first headers, which `consistency-diff.sh` does not emit. Corrected to the real reverse order, with a test pinning it.

**Fix:** strip either prefix (`/^[ab]\//`).

## LL-tagged headers

saucal/action-deploy-ssh#21 flags a file whose long lines were truncated:

```
diff --git --simple LL b/plugins/ui/dist/app.min.js a/plugins/ui/dist/app.min.js
```

The tag warns a human that the body will not apply as a patch. The file is modified like any other, so it parses as `M`. Two paths after the tag is what distinguishes it from the bodiless one-liners, which keep their own status — a new test pins that `--simple WS <path>` is not misread as a tagged header.

`LL` therefore never appears as a *status*, and comes back out of `MODIFIED_STATUSES` (which stays `M`, `WS`).

## Testing

86/86 green (`npm test`). New tests: the `b/` strip, an LL-tagged header parsing as `M`, and the tagged-vs-bodiless distinction.

## Merge order

The prefix fix stands alone and should land regardless. The LL parsing is inert until #21 ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJiAywUjzsbkRbZNESL2y5